### PR TITLE
1.1.0

### DIFF
--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -931,6 +931,54 @@ class ConvertKit_API {
 	}
 
 	/**
+	 * Fetches all products from the API.
+	 *
+	 * @since   1.1.0
+	 *
+	 * @return  WP_Error|array
+	 */
+	public function get_products() {
+
+		$this->log( 'API: get_products()' );
+
+		$products = array();
+
+		// Send request.
+		$response = $this->get(
+			'products',
+			array(
+				'api_key'    => $this->api_key,
+				'api_secret' => $this->api_secret,
+			)
+		);
+
+		// If an error occured, log and return it now.
+		if ( is_wp_error( $response ) ) {
+			$this->log( 'API: get_products(): Error: ' . $response->get_error_message() );
+			return $response;
+		}
+
+		// If the response isn't an array as we expect, log that no products exist and return a blank array.
+		if ( ! is_array( $response['products'] ) ) {
+			$this->log( 'API: get_products(): Error: No products exist in ConvertKit.' );
+			return new WP_Error( 'convertkit_api_error', $this->get_error_message( 'response_type_unexpected' ) );
+		}
+
+		// If no products exist, log that no products exist and return a blank array.
+		if ( ! count( $response['products'] ) ) {
+			$this->log( 'API: get_products(): Error: No products exist in ConvertKit.' );
+			return $products;
+		}
+
+		foreach ( $response['products'] as $product ) {
+			$products[] = $product;
+		}
+
+		return $products;
+
+	}
+
+	/**
 	 * Get HTML from ConvertKit for the given Legacy Form ID.
 	 *
 	 * This isn't specifically an API function, but for now it's best suited here.
@@ -1537,6 +1585,11 @@ class ConvertKit_API {
 		// For the /posts endpoint, the API base is https://api.convertkit.com/api/v3/$endpoint.
 		if ( $endpoint === 'posts' ) {
 			return path_join( $this->api_url_base . 'api/' . $this->api_version, $endpoint );
+		}
+
+		// For the /products endpoint, the API base is https://api.convertkit.com/wordpress/$endpoint.
+		if ( $endpoint === 'products' ) {
+			return path_join( $this->api_url_base . 'wordpress', $endpoint ); // phpcs:ignore WordPress.WP.CapitalPDangit
 		}
 
 		// For all other endpoints, it's https://api.convertkit.com/v3/$endpoint.

--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -375,7 +375,7 @@ class ConvertKit_API {
 		}
 
 		foreach ( $response['courses'] as $sequence ) {
-			$sequences[] = $sequence;
+			$sequences[ $sequence['id'] ] = $sequence;
 		}
 
 		return $sequences;
@@ -485,7 +485,7 @@ class ConvertKit_API {
 		}
 
 		foreach ( $response['tags'] as $tag ) {
-			$tags[] = $tag;
+			$tags[ $tag['id'] ] = $tag;
 		}
 
 		return $tags;
@@ -797,7 +797,7 @@ class ConvertKit_API {
 		}
 
 		foreach ( $response['custom_fields'] as $custom_field ) {
-			$custom_fields[] = $custom_field;
+			$custom_fields[ $custom_field['id'] ] = $custom_field;
 		}
 
 		return $custom_fields;
@@ -853,7 +853,7 @@ class ConvertKit_API {
 
 			// Append posts to array.
 			foreach ( $response['posts'] as $post ) {
-				$posts[] = $post;
+				$posts[ $post['id'] ] = $post;
 			}
 		}
 
@@ -971,7 +971,7 @@ class ConvertKit_API {
 		}
 
 		foreach ( $response['products'] as $product ) {
-			$products[] = $product;
+			$products[ $product['id'] ] = $product;
 		}
 
 		return $products;

--- a/src/class-convertkit-resource.php
+++ b/src/class-convertkit-resource.php
@@ -269,6 +269,10 @@ class ConvertKit_Resource {
 				$results = $this->api->get_all_posts();
 				break;
 
+			case 'products':
+				$results = $this->api->get_products();
+				break;
+
 			default:
 				$results = new WP_Error(
 					'convertkit_resource_refresh_error',

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -991,6 +991,36 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
+	 * Test that the `get_products()` function returns expected data.
+	 * 
+	 * @since 	1.1.0
+	 */
+	public function testGetProducts()
+	{
+		$result = $this->api->get_products();
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
+		$this->assertArrayHasKey('url', reset($result));
+		$this->assertArrayHasKey('published', reset($result));
+	}
+
+	/**
+	 * Test that the `get_products()` function returns a blank array when no data
+	 * exists on the ConvertKit account.
+	 * 
+	 * @since 	1.1.0
+	 */
+	public function testGetProductsNoData()
+	{
+		$result = $this->api_no_data->get_forms();
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
+	}
+
+	/**
 	 * Test that the `purchase_create()` function returns expected data
 	 * when valid parameters are provided.
 	 * 


### PR DESCRIPTION
## Summary

- Added: API: `get_products()` function to call [the products API endpoint](https://github.com/ConvertKit/convertkit/pull/21185)
- Added: Resources: Refresh ConvertKit Products
- Fixed: API: Set array keys to IDs for Sequences, Tags, Custom Fields and Posts, to match Forms and Landing Pages

## Testing

- `APITest:testGetProducts`: Test that the call to `get_products()` works as expected
- `APITest:testGetProductsNoData`: Test that the call to `get_products()` works as expected when the ConvertKit account has no Products

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)