### PR TITLE
1.2.0

### DIFF
--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -30,8 +30,8 @@ class ConvertKit_API {
 
 	/**
 	 * Optional context of the request.
-	 * 
-	 * @var 	bool|string
+	 *
+	 * @var     bool|string
 	 */
 	protected $context = false;
 
@@ -107,7 +107,7 @@ class ConvertKit_API {
 	 * @param   bool|string $api_key        ConvertKit API Key.
 	 * @param   bool|string $api_secret     ConvertKit API Secret.
 	 * @param   bool|object $debug          Save data to log.
-	 * @param 	bool|string $context 		Context of originating request.
+	 * @param   bool|string $context        Context of originating request.
 	 */
 	public function __construct( $api_key = false, $api_secret = false, $debug = false, $context = false ) {
 
@@ -115,7 +115,7 @@ class ConvertKit_API {
 		$this->api_key        = $api_key;
 		$this->api_secret     = $api_secret;
 		$this->debug          = $debug;
-		$this->context 		  = $context;
+		$this->context        = $context;
 		$this->plugin_name    = ( defined( 'CONVERTKIT_PLUGIN_NAME' ) ? CONVERTKIT_PLUGIN_NAME : false );
 		$this->plugin_path    = ( defined( 'CONVERTKIT_PLUGIN_PATH' ) ? CONVERTKIT_PLUGIN_PATH : false );
 		$this->plugin_url     = ( defined( 'CONVERTKIT_PLUGIN_URL' ) ? CONVERTKIT_PLUGIN_URL : false );
@@ -1580,7 +1580,7 @@ class ConvertKit_API {
 				$this->plugin_version,
 				home_url( '/' ),
 				$this->context
-			);	
+			);
 		}
 
 		return sprintf(

--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -1573,7 +1573,7 @@ class ConvertKit_API {
 		// If a context is specified, include it now.
 		if ( $this->context !== false ) {
 			return sprintf(
-				'WordPress/%1$s;PHP/%2$s;%3$s/%4$s;%5$s/%6$s',
+				'WordPress/%1$s;PHP/%2$s;%3$s/%4$s;%5$s;context/%6$s',
 				$wp_version,
 				phpversion(),
 				$this->plugin_name,

--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -29,6 +29,13 @@ class ConvertKit_API {
 	protected $api_secret = false;
 
 	/**
+	 * Optional context of the request.
+	 * 
+	 * @var 	bool|string
+	 */
+	protected $context = false;
+
+	/**
 	 * Save debug data to log
 	 *
 	 * @var  bool
@@ -100,13 +107,15 @@ class ConvertKit_API {
 	 * @param   bool|string $api_key        ConvertKit API Key.
 	 * @param   bool|string $api_secret     ConvertKit API Secret.
 	 * @param   bool|object $debug          Save data to log.
+	 * @param 	bool|string $context 		Context of originating request.
 	 */
-	public function __construct( $api_key = false, $api_secret = false, $debug = false ) {
+	public function __construct( $api_key = false, $api_secret = false, $debug = false, $context = false ) {
 
 		// Set API credentials, debugging and logging class.
 		$this->api_key        = $api_key;
 		$this->api_secret     = $api_secret;
 		$this->debug          = $debug;
+		$this->context 		  = $context;
 		$this->plugin_name    = ( defined( 'CONVERTKIT_PLUGIN_NAME' ) ? CONVERTKIT_PLUGIN_NAME : false );
 		$this->plugin_path    = ( defined( 'CONVERTKIT_PLUGIN_PATH' ) ? CONVERTKIT_PLUGIN_PATH : false );
 		$this->plugin_url     = ( defined( 'CONVERTKIT_PLUGIN_URL' ) ? CONVERTKIT_PLUGIN_URL : false );
@@ -1560,6 +1569,19 @@ class ConvertKit_API {
 
 		// Include an unmodified $wp_version.
 		require ABSPATH . WPINC . '/version.php';
+
+		// If a context is specified, include it now.
+		if ( $this->context !== false ) {
+			return sprintf(
+				'WordPress/%1$s;PHP/%2$s;%3$s/%4$s;%5$s/%6$s',
+				$wp_version,
+				phpversion(),
+				$this->plugin_name,
+				$this->plugin_version,
+				home_url( '/' ),
+				$this->context
+			);	
+		}
 
 		return sprintf(
 			'WordPress/%1$s;PHP/%2$s;%3$s/%4$s;%5$s',

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -106,6 +106,43 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
+	 * Test that the User Agent string is in the expected format when
+	 * a context is provided.
+	 * 
+	 * @since 	1.2.0
+	 */
+	public function testUserAgentWithContext()
+	{
+		// When an API call is made, inspect the user-agent argument.
+		add_filter('http_request_args', function($args, $url) {
+			$this->assertStringContainsString(';context/TestContext', $args['user-agent']);
+			return $args;
+		}, 10, 2);
+
+		// Perform a request.
+		$api = new ConvertKit_API( $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], false, 'TestContext' );
+		$result = $api->account();
+	}
+
+	/**
+	 * Test that the User Agent string is in the expected format when
+	 * no context is provided.
+	 * 
+	 * @since 	1.2.0
+	 */
+	public function testUserAgentWithoutContext()
+	{
+		// When an API call is made, inspect the user-agent argument.
+		add_filter('http_request_args', function($args, $url) {
+			$this->assertStringNotContainsString(';context/TestContext', $args['user-agent']);
+			return $args;
+		}, 10, 2);
+
+		// Perform a request.
+		$result = $this->api->account();
+	}
+
+	/**
 	 * Test that supplying invalid API credentials to the API class returns a WP_Error.
 	 * 
 	 * @since 	1.0.0


### PR DESCRIPTION
## Summary

- Added: API: Option to specify a `context` parameter, which is included in the User-Agent for detailing what function made a call [as implemented in this PR](https://github.com/ConvertKit/convertkit-wordpress/pull/366)

## Testing

- `APITest: testUserAgentWithContex`: Test that the context string is included in the User-Agent when defined in the API class constructor.
- `APITest: testUserAgentWithoutContext`: Test that no context string is included in the User-Agent when not defined in the API class constructor.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)