### PR TITLE
Handle null return value from json_decode

### DIFF
--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -172,10 +172,7 @@ class ConvertKit_API {
 			'request_rate_limit_exceeded'                 => __( 'ConvertKit API Error: Rate limit hit.', 'convertkit' ),
 			'request_internal_server_error'               => __( 'ConvertKit API Error: Internal server error.', 'convertkit' ),
 			'request_bad_gateway'                 		  => __( 'ConvertKit API Error: Bad gateway.', 'convertkit' ),
-			
-			/* translators: API response body */
-			'response_type_null' 					  	  => __( 'ConvertKit API Error: A null response was encountered when JSON decoding %s', 'convertkit' ),
-			'response_type_unexpected' 					  => __( 'The response from the API is not of the expected type array.', 'convertkit' ),
+			'response_type_unexpected' 					  => __( 'ConvertKit API Error: The response is not of the expected type array.', 'convertkit' ),
 		);
 		// phpcs:enable
 
@@ -1540,8 +1537,8 @@ class ConvertKit_API {
 
 		// If the response is null, json_decode() failed as the body could not be decoded.
 		if ( is_null( $response ) ) {
-			$this->log( 'API: Error: ' . sprintf( $this->get_error_message( 'response_type_null' ), $body ) );
-			return new WP_Error( 'convertkit_api_error', sprintf( $this->get_error_message( 'response_type_null' ), $body ) );
+			$this->log( 'API: Error: ' . sprintf( $this->get_error_message( 'response_type_unexpected' ), $body ) );
+			return new WP_Error( 'convertkit_api_error', sprintf( $this->get_error_message( 'response_type_unexpected' ), $body ) );
 		}
 
 		// If an error message or code exists in the response, return a WP_Error.

--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -173,6 +173,8 @@ class ConvertKit_API {
 			'request_internal_server_error'               => __( 'ConvertKit API Error: Internal server error.', 'convertkit' ),
 			'request_bad_gateway'                 		  => __( 'ConvertKit API Error: Bad gateway.', 'convertkit' ),
 			
+			/* translators: API response body */
+			'response_type_null' 					  	  => __( 'ConvertKit API Error: A null response was encountered when JSON decoding %s', 'convertkit' ),
 			'response_type_unexpected' 					  => __( 'The response from the API is not of the expected type array.', 'convertkit' ),
 		);
 		// phpcs:enable
@@ -1534,6 +1536,12 @@ class ConvertKit_API {
 			// Bad gateway.
 			case 502:
 				return new WP_Error( 'convertkit_api_error', $this->get_error_message( 'request_bad_gateway' ) );
+		}
+
+		// If the response is null, json_decode() failed as the body could not be decoded.
+		if ( is_null( $response ) ) {
+			$this->log( 'API: Error: ' . sprintf( $this->get_error_message( 'response_type_null' ), $body ) );
+			return new WP_Error( 'convertkit_api_error', sprintf( $this->get_error_message( 'response_type_null' ), $body ) );
 		}
 
 		// If an error message or code exists in the response, return a WP_Error.

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -120,7 +120,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$result = $this->api->get_posts(); // The API function we use doesn't matter.
 		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
-		$this->assertEquals($result->get_error_message(), 'ConvertKit API Error: A null response was encountered when JSON decoding invalid JSON string');
+		$this->assertEquals($result->get_error_message(), 'ConvertKit API Error: The response is not of the expected type array.');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Returns a `WP_Error` object when using `json_decode()` on the API response body returns null.

Reported [here](https://wordpress.org/support/topic/php-warning-trying-to-access-array-offset-on-value-of-type-null-in-2/), although it's unclear why making a call to `https://api.convertkit.com/api/v3/posts` with an `api_secret` would return an invalid JSON string, as this wasn't reproducible in our several unit tests for fetching posts with valid / invalid parameters on accounts with and without posts. 

## Testing

- `APITest:testNullResponse`: Test that a response containing invalid JSON, resulting in json_decode() returning null, gracefully returns a WP_Error.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)