### PR TITLE
Fix incorrect version numbers in docblocks

### DIFF
--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -845,7 +845,7 @@ class ConvertKit_API {
 	/**
 	 * Gets all posts from the API.
 	 *
-	 * @since   1.9.7.6
+	 * @since   1.0.0
 	 *
 	 * @param   int $posts_per_request   Number of Posts to fetch in each request.
 	 * @return  WP_Error|array
@@ -908,7 +908,7 @@ class ConvertKit_API {
 	/**
 	 * Gets posts from the API.
 	 *
-	 * @since   1.9.7.4
+	 * @since   1.0.0
 	 *
 	 * @param   int $page       Page number.
 	 * @param   int $per_page   Number of Posts to return.
@@ -1621,7 +1621,7 @@ class ConvertKit_API {
 	/**
 	 * Performs a PUT request.
 	 *
-	 * @since  1.9.7.8
+	 * @since  1.0.0
 	 *
 	 * @param   string $endpoint       API Endpoint.
 	 * @param   array  $params         Params.
@@ -1766,7 +1766,7 @@ class ConvertKit_API {
 		/**
 		 * Defines the maximum time to allow the API request to run.
 		 *
-		 * @since   2.2.9
+		 * @since   1.0.0
 		 *
 		 * @param   int     $timeout    Timeout, in seconds.
 		 */
@@ -1857,7 +1857,7 @@ class ConvertKit_API {
 	/**
 	 * Returns the localized/translated error message for the given error key.
 	 *
-	 * @since   1.9.7.8
+	 * @since   1.0.0
 	 *
 	 * @param   string $key    Key.
 	 * @return  string          Error message

--- a/src/class-convertkit-log.php
+++ b/src/class-convertkit-log.php
@@ -9,14 +9,14 @@
 /**
  * Class to read and write to the ConvertKit log file.
  *
- * @since   1.9.6
+ * @since   1.0.0
  */
 class ConvertKit_Log {
 
 	/**
 	 * The path and filename of the log file.
 	 *
-	 * @since   1.9.6
+	 * @since   1.0.0
 	 *
 	 * @var     string
 	 */
@@ -25,7 +25,7 @@ class ConvertKit_Log {
 	/**
 	 * Constructor. Defines the log file location.
 	 *
-	 * @since   1.9.6
+	 * @since   1.0.0
 	 *
 	 * @param   string $path   Path to where log file should be created/edited/read.
 	 */
@@ -43,7 +43,7 @@ class ConvertKit_Log {
 	/**
 	 * Returns the path and filename of the log file.
 	 *
-	 * @since   1.9.6
+	 * @since   1.0.0
 	 *
 	 * @return string
 	 */
@@ -56,7 +56,7 @@ class ConvertKit_Log {
 	/**
 	 * Whether the log file exists.
 	 *
-	 * @since   1.9.6
+	 * @since   1.0.0
 	 *
 	 * @return  bool
 	 */
@@ -69,7 +69,7 @@ class ConvertKit_Log {
 	/**
 	 * Adds an entry to the log file.
 	 *
-	 * @since   1.9.6
+	 * @since   1.0.0
 	 *
 	 * @param   string $entry  Log Line Entry.
 	 */
@@ -95,7 +95,7 @@ class ConvertKit_Log {
 	/**
 	 * Reads the given number of lines from the log file.
 	 *
-	 * @since   1.9.6
+	 * @since   1.0.0
 	 *
 	 * @param   int $number_of_lines    Number of Lines.
 	 * @return  string                      Log file data
@@ -126,7 +126,7 @@ class ConvertKit_Log {
 	/**
 	 * Clears the log file without deleting the log file.
 	 *
-	 * @since   1.9.6
+	 * @since   1.0.0
 	 */
 	public function clear() {
 
@@ -140,7 +140,7 @@ class ConvertKit_Log {
 	/**
 	 * Deletes the log file.
 	 *
-	 * @since   1.9.6
+	 * @since   1.0.0
 	 */
 	public function delete() {
 

--- a/src/class-convertkit-resource.php
+++ b/src/class-convertkit-resource.php
@@ -10,7 +10,7 @@
  * Abstract class defining variables and functions for a ConvertKit API Resource
  * (forms, landing pages, tags), which is stored in the WordPress option table.
  *
- * @since   1.9.6
+ * @since   1.0.0
  */
 class ConvertKit_Resource {
 
@@ -48,7 +48,7 @@ class ConvertKit_Resource {
 	 * If false, won't be refreshed through WordPress' Cron
 	 * If a string, must be a value from wp_get_schedules().
 	 *
-	 * @since   1.9.7.4
+	 * @since   1.0.0
 	 *
 	 * @var     bool|string
 	 */
@@ -65,7 +65,7 @@ class ConvertKit_Resource {
 	 * Timestamp for when the resources stored in the option database table
 	 * were last queried from the API.
 	 *
-	 * @since   1.9.7.4
+	 * @since   1.0.0
 	 *
 	 * @var     int
 	 */
@@ -74,7 +74,7 @@ class ConvertKit_Resource {
 	/**
 	 * Constructor.
 	 *
-	 * @since   1.9.6
+	 * @since   1.0.0
 	 */
 	public function __construct() {
 
@@ -86,7 +86,7 @@ class ConvertKit_Resource {
 	 * Initialization routine. Populate the resources array of e.g. forms, landing pages or tags,
 	 * depending on whether resources are already cached, if the resources have expired etc.
 	 *
-	 * @since   1.9.7.4
+	 * @since   1.0.0
 	 */
 	public function init() {
 
@@ -113,7 +113,7 @@ class ConvertKit_Resource {
 	/**
 	 * Returns all resources.
 	 *
-	 * @since   1.9.6
+	 * @since   1.0.0
 	 *
 	 * @return  array
 	 */
@@ -126,7 +126,7 @@ class ConvertKit_Resource {
 	/**
 	 * Returns an individual resource by its ID.
 	 *
-	 * @since   1.9.7.7
+	 * @since   1.0.0
 	 *
 	 * @param   int $id     Resource ID (Form, Tag, Sequence).
 	 * @return  mixed           bool | array
@@ -149,7 +149,7 @@ class ConvertKit_Resource {
 	 * Returns a paginated subset of resources, including whether
 	 * previous and next resources in the array exist.
 	 *
-	 * @since   1.9.7.6
+	 * @since   1.0.0
 	 *
 	 * @param   int $page   Current Page.
 	 * @param   int $per_page   Number of resources to return per page.
@@ -193,7 +193,7 @@ class ConvertKit_Resource {
 	/**
 	 * Returns the number of resources.
 	 *
-	 * @since   1.9.7.6
+	 * @since   1.0.0
 	 *
 	 * @return  int
 	 */
@@ -206,7 +206,7 @@ class ConvertKit_Resource {
 	/**
 	 * Returns whether any resources exist in the options table.
 	 *
-	 * @since   1.9.6
+	 * @since   1.0.0
 	 *
 	 * @return  bool
 	 */
@@ -232,7 +232,7 @@ class ConvertKit_Resource {
 	 * Fetches resources (forms, landing pages or tags) from the API, storing them in the options table
 	 * with a last queried timestamp.
 	 *
-	 * @since   1.9.6
+	 * @since   1.0.0
 	 *
 	 * @return  bool|WP_Error|array
 	 */
@@ -324,7 +324,7 @@ class ConvertKit_Resource {
 	 * Schedules a WordPress Cron event to refresh this resource based on
 	 * the resource's $wp_cron_schedule.
 	 *
-	 * @since   1.9.7.4
+	 * @since   1.0.0
 	 */
 	public function schedule_cron_event() {
 
@@ -350,7 +350,7 @@ class ConvertKit_Resource {
 	/**
 	 * Unschedules a WordPress Cron event to refresh this resource.
 	 *
-	 * @since   1.9.7.4
+	 * @since   1.0.0
 	 */
 	public function unschedule_cron_event() {
 
@@ -364,7 +364,7 @@ class ConvertKit_Resource {
 	 * Returns false if no schedule exists i.e. wp_schedule_event() has not been
 	 * called or failed to register a scheduled event.
 	 *
-	 * @since   1.9.7.4
+	 * @since   1.0.0
 	 *
 	 * @return  bool|string
 	 */
@@ -377,7 +377,7 @@ class ConvertKit_Resource {
 	/**
 	 * Deletes resources (forms, landing pages or tags) from the options table.
 	 *
-	 * @since   1.9.7.8
+	 * @since   1.0.0
 	 */
 	public function delete() {
 

--- a/src/class-convertkit-review-request.php
+++ b/src/class-convertkit-review-request.php
@@ -18,7 +18,7 @@ class ConvertKit_Review_Request {
 	/**
 	 * Holds the Plugin name.
 	 *
-	 * @since   1.9.6.7
+	 * @since   1.0.0
 	 *
 	 * @var     string
 	 */
@@ -27,7 +27,7 @@ class ConvertKit_Review_Request {
 	/**
 	 * Holds the Plugin slug.
 	 *
-	 * @since   1.9.6.7
+	 * @since   1.0.0
 	 *
 	 * @var     string
 	 */
@@ -36,7 +36,7 @@ class ConvertKit_Review_Request {
 	/**
 	 * Holds the Plugin path.
 	 *
-	 * @since   1.9.7.8
+	 * @since   1.0.0
 	 *
 	 * @var     string
 	 */
@@ -46,7 +46,7 @@ class ConvertKit_Review_Request {
 	 * Holds the number of days after the Plugin requests a review to then
 	 * display the review notification in WordPress' Administration interface.
 	 *
-	 * @since   1.9.6.7
+	 * @since   1.0.0
 	 *
 	 * @var     int
 	 */
@@ -55,7 +55,7 @@ class ConvertKit_Review_Request {
 	/**
 	 * Registers action and filter hooks.
 	 *
-	 * @since   1.9.6.7
+	 * @since   1.0.0
 	 *
 	 * @param   string $plugin_name    Plugin Name (e.g. ConvertKit).
 	 * @param   string $plugin_slug    Plugin Slug (e.g. convertkit).
@@ -80,7 +80,7 @@ class ConvertKit_Review_Request {
 	 * Displays a dismissible WordPress Administration notice requesting a review, if requested
 	 * by the main Plugin and the Review Request hasn't been disabled.
 	 *
-	 * @since   1.9.6.7
+	 * @since   1.0.0
 	 */
 	public function maybe_display_review_request() {
 
@@ -118,7 +118,7 @@ class ConvertKit_Review_Request {
 	 * Sets a flag in the options table requesting a review notification be displayed
 	 * in the WordPress Administration.
 	 *
-	 * @since   1.9.6.7
+	 * @since   1.0.0
 	 */
 	public function request_review() {
 
@@ -138,7 +138,7 @@ class ConvertKit_Review_Request {
 	 * and the minimum time has passed between the Plugin requesting a review
 	 * and now.
 	 *
-	 * @since   1.9.6.7
+	 * @since   1.0.0
 	 *
 	 * @return  bool    Review Requested
 	 */
@@ -163,7 +163,7 @@ class ConvertKit_Review_Request {
 	/**
 	 * Dismisses the review notification, so it isn't displayed again.
 	 *
-	 * @since   1.9.6.7
+	 * @since   1.0.0
 	 */
 	public function dismiss_review() {
 
@@ -179,7 +179,7 @@ class ConvertKit_Review_Request {
 	/**
 	 * Flag to indicate whether a review request has been dismissed by the user.
 	 *
-	 * @since   1.9.6.7
+	 * @since   1.0.0
 	 *
 	 * @return  bool    Review Dismissed
 	 */
@@ -192,7 +192,7 @@ class ConvertKit_Review_Request {
 	/**
 	 * Returns the Review URL for this Plugin.
 	 *
-	 * @since   1.9.6.7
+	 * @since   1.0.0
 	 *
 	 * @return  string  Review URL
 	 */
@@ -205,7 +205,7 @@ class ConvertKit_Review_Request {
 	/**
 	 * Returns the Support URL for this Plugin.
 	 *
-	 * @since   1.9.6.7
+	 * @since   1.0.0
 	 *
 	 * @return  string  Review URL
 	 */


### PR DESCRIPTION
## Summary

Fixes incorrect version numbers in docblocks when classes were first abstracted from the main ConvertKit Plugin to this separate library.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)