### PR TITLE
Sort Resources

### DIFF
--- a/src/class-convertkit-resource.php
+++ b/src/class-convertkit-resource.php
@@ -71,6 +71,15 @@ class ConvertKit_Resource {
 	public $order_by = 'name';
 
 	/**
+	 * The order to return resources.
+	 *
+	 * @since   1.3.1
+	 *
+	 * @var     string
+	 */
+	public $order = 'asc';
+
+	/**
 	 * Timestamp for when the resources stored in the option database table
 	 * were last queried from the API.
 	 *
@@ -137,13 +146,18 @@ class ConvertKit_Resource {
 			return $resources;
 		}
 
-		// Sort resources alphabetically by the order_by setting.
+		// Sort resources ascending by the order_by setting.
 		uasort(
 			$resources,
 			function( $a, $b ) {
 				return strcmp( $a[ $this->order_by ], $b[ $this->order_by ] );
 			}
 		);
+
+		// Reverse the array if the results should be returned in descending order.
+		if ( $this->order === 'desc' ) {
+			$resources = array_reverse( $resources, true );
+		}
 
 		return $resources;
 
@@ -198,7 +212,7 @@ class ConvertKit_Resource {
 
 		return array(
 			// The subset of items based on the pagination.
-			'items'         => array_slice( $this->resources, ( $page * $per_page ) - $per_page, $per_page ),
+			'items'         => array_slice( $this->get(), ( $page * $per_page ) - $per_page, $per_page ),
 
 			// Sanitized inputs.
 			'page'          => $page,

--- a/src/class-convertkit-resource.php
+++ b/src/class-convertkit-resource.php
@@ -62,6 +62,13 @@ class ConvertKit_Resource {
 	public $resources = array();
 
 	/**
+	 * The key to use when alphabetically sorting resources.
+	 * 
+	 * @since 	1.3.1
+	 */
+	public $order_by = 'name';
+
+	/**
 	 * Timestamp for when the resources stored in the option database table
 	 * were last queried from the API.
 	 *
@@ -111,15 +118,29 @@ class ConvertKit_Resource {
 	}
 
 	/**
-	 * Returns all resources.
+	 * Returns all resources based on the sort order.
 	 *
-	 * @since   1.9.6
+	 * @since   1.0.0
 	 *
 	 * @return  array
 	 */
 	public function get() {
 
-		return $this->resources;
+		// Don't modify the underlying resources.
+		$resources = $this->resources;
+
+		// Don't attempt sorting if the order_by setting doesn't exist as a key
+		// in the API response.
+		if ( ! array_key_exists( $this->order_by, reset( $resources ) ) ) {
+			return $resources;
+		}
+
+		// Sort resources alphabetically by the order_by setting.
+		uasort( $resources, function( $a, $b ) {
+			return strcmp( $a[ $this->order_by ], $b[ $this->order_by ] );
+		} );
+
+		return $resources;
 
 	}
 

--- a/src/class-convertkit-resource.php
+++ b/src/class-convertkit-resource.php
@@ -63,8 +63,10 @@ class ConvertKit_Resource {
 
 	/**
 	 * The key to use when alphabetically sorting resources.
-	 * 
-	 * @since 	1.3.1
+	 *
+	 * @since   1.3.1
+	 *
+	 * @var     string
 	 */
 	public $order_by = 'name';
 
@@ -136,9 +138,12 @@ class ConvertKit_Resource {
 		}
 
 		// Sort resources alphabetically by the order_by setting.
-		uasort( $resources, function( $a, $b ) {
-			return strcmp( $a[ $this->order_by ], $b[ $this->order_by ] );
-		} );
+		uasort(
+			$resources,
+			function( $a, $b ) {
+				return strcmp( $a[ $this->order_by ], $b[ $this->order_by ] );
+			}
+		);
 
 		return $resources;
 

--- a/src/class-convertkit-resource.php
+++ b/src/class-convertkit-resource.php
@@ -137,16 +137,17 @@ class ConvertKit_Resource {
 	 */
 	public function get() {
 
-		// Don't modify the underlying resources.
+		// Don't mutate the underlying resources, so multiple calls to get()
+		// with different order_by and order properties are supported.
 		$resources = $this->resources;
 
-		// Don't attempt sorting if the order_by setting doesn't exist as a key
+		// Don't attempt sorting if the order_by property doesn't exist as a key
 		// in the API response.
 		if ( ! array_key_exists( $this->order_by, reset( $resources ) ) ) {
 			return $resources;
 		}
 
-		// Sort resources ascending by the order_by setting.
+		// Sort resources ascending by the order_by property.
 		uasort(
 			$resources,
 			function( $a, $b ) {

--- a/tests/wpunit/ResourceTest.php
+++ b/tests/wpunit/ResourceTest.php
@@ -36,6 +36,24 @@ class ResourceTest extends \Codeception\TestCase\WPTestCase
 
 		// Initialize the classes we want to test.
 		$this->resource = new ConvertKit_Resource();
+
+		// Mock the data that the resource class would receive from the WordPress options table
+		// (and therefore the ConvertKit APIs) to perform tests on.
+		$this->resource->resources = [
+			2780977 => [
+				'id'         	=> 2780977,
+				'name'       	=> 'Z Name', // 'name' used by forms, landing pages, products, tags.
+				'title'		 	=> 'Z Name', // 'title' used by posts.
+				'published_at' 	=> '2022-01-24T00:00:00.000Z', // used by posts.
+			],
+			2765139 => [
+				'id'         	=> 2765139,
+				'name'       	=> 'A Name', // 'name' used by forms, landing pages, products, tags.
+				'title'		 	=> 'A Name', // 'title' used by posts.
+				'published_at' 	=> '2022-05-03T14:51:50.000Z', // used by posts.
+			],
+		];
+
 	}
 
 	/**
@@ -46,33 +64,19 @@ class ResourceTest extends \Codeception\TestCase\WPTestCase
 	public function tearDown(): void
 	{
 		// Destroy the classes we tested.
-		unset($this->api);
-		unset($this->api_no_data);
+		unset($this->resource);
 
 		parent::tearDown();
 	}
 
 	/**
-	 * Tests that the get() function returns resources in alphabetical order when
-	 * populated with Forms.
+	 * Tests that the get() function returns resources in alphabetical ascending order
+	 * by default.
 	 * 
 	 * @since 	1.3.1
 	 */
-	public function testGetForms()
+	public function testGet()
 	{
-		// Mock the data that the resource class would fetch from the WordPress options table
-		// (and therefore the ConvertKit API), deliberately in a non-alphabetical order.
-		$this->resource->resources = [
-			2765139 => [
-				'id'         => 2765139,
-				'name'       => 'Page Form',
-			],
-			2780977 => [
-				'id'         => 2780977,
-				'name'       => 'Modal Form',
-			]
-		];
-
 		// Call resource class' get() function.
 		$result = $this->resource->get();
 
@@ -83,9 +87,35 @@ class ResourceTest extends \Codeception\TestCase\WPTestCase
 		$this->assertArrayHasKey(array_key_first($this->resource->resources), $result);
 		$this->assertArrayHasKey(array_key_last($this->resource->resources), $result);
 
-		// Assert order of data is alphabetical.
-		$this->assertEquals(reset($this->resource->resources)['name'], end($result)['name']);
-		$this->assertEquals(end($this->resource->resources)['name'], reset($result)['name']);
+		// Assert order of data is in ascending alphabetical order.
+		$this->assertEquals('A Name', reset($result)[ $this->resource->order_by ]);
+		$this->assertEquals('Z Name', end($result)[ $this->resource->order_by ]);
+	}
+
+	/**
+	 * Tests that the get() function returns resources in alphabetical ascending order
+	 * when a valid order_by setting is defined.
+	 * 
+	 * @since 	1.3.1
+	 */
+	public function testGetWithValidOrderBy()
+	{
+		// Define order_by = title.
+		$this->resource->order_by = 'title';
+
+		// Call resource class' get() function.
+		$result = $this->resource->get();
+
+		// Assert result is an array, and no error occured.
+		$this->assertIsArray($result);
+
+		// Assert array keys are preserved.
+		$this->assertArrayHasKey(array_key_first($this->resource->resources), $result);
+		$this->assertArrayHasKey(array_key_last($this->resource->resources), $result);
+
+		// Assert order of data is in ascending alphabetical order.
+		$this->assertEquals('A Name', reset($result)[ $this->resource->order_by ]);
+		$this->assertEquals('Z Name', end($result)[ $this->resource->order_by ]);
 	}
 
 	/**
@@ -94,22 +124,9 @@ class ResourceTest extends \Codeception\TestCase\WPTestCase
 	 * 
 	 * @since 	1.3.1
 	 */
-	public function testGetFormsWithInvalidOrderBy()
+	public function testGetWithInvalidOrderBy()
 	{
-		// Mock the data that the resource class would fetch from the WordPress options table
-		// (and therefore the ConvertKit API), deliberately in a non-alphabetical order.
-		$this->resource->resources = [
-			2765139 => [
-				'id'         => 2765139,
-				'name'       => 'Page Form',
-			],
-			2780977 => [
-				'id'         => 2780977,
-				'name'       => 'Modal Form',
-			],
-		];
-
-		// Define the sort order with an invalid value.
+		// Define order_by with an invalid value (i.e. an array key that does not exist).
 		$this->resource->order_by = 'invalid_key';
 
 		// Call resource class' get() function.
@@ -121,6 +138,63 @@ class ResourceTest extends \Codeception\TestCase\WPTestCase
 		// Assert array keys are preserved.
 		$this->assertArrayHasKey(array_key_first($this->resource->resources), $result);
 		$this->assertArrayHasKey(array_key_last($this->resource->resources), $result);
+
+		// Assert order of data has not changed.
+		$this->assertNotEquals('A Name', reset($result)['name']);
+		$this->assertNotEquals('Z Name', end($result)['name']);
 	}
 
+	/**
+	 * Tests that the get() function returns resources in alphabetical descending order
+	 * when a valid order_by setting is defined.
+	 * 
+	 * @since 	1.3.1
+	 */
+	public function testGetWithValidOrder()
+	{
+		// Define order to be descending.
+		$this->resource->order_by = 'name';
+		$this->resource->order = 'desc';
+
+		// Call resource class' get() function.
+		$result = $this->resource->get();
+
+		// Assert result is an array, and no error occured.
+		$this->assertIsArray($result);
+
+		// Assert array keys are preserved.
+		$this->assertArrayHasKey(array_key_first($this->resource->resources), $result);
+		$this->assertArrayHasKey(array_key_last($this->resource->resources), $result);
+
+		// Assert order of data is in descending alphabetical order.
+		$this->assertEquals('Z Name', reset($result)[ $this->resource->order_by ]);
+		$this->assertEquals('A Name', end($result)[ $this->resource->order_by ]);
+	}
+
+	/**
+	 * Tests that the get() function returns resources in date descending order
+	 * when a valid order and order_by settings are defined.
+	 * 
+	 * @since 	1.3.1
+	 */
+	public function testGetWithValidOrderByAndOrder()
+	{
+		// Define order to be descending.
+		$this->resource->order_by = 'published_at';
+		$this->resource->order = 'desc';
+
+		// Call resource class' get() function.
+		$result = $this->resource->get();
+
+		// Assert result is an array, and no error occured.
+		$this->assertIsArray($result);
+
+		// Assert array keys are preserved.
+		$this->assertArrayHasKey(array_key_first($this->resource->resources), $result);
+		$this->assertArrayHasKey(array_key_last($this->resource->resources), $result);
+
+		// Assert order of data is in descending alphabetical order.
+		$this->assertEquals('2022-05-03T14:51:50.000Z', reset($result)['published_at']);
+		$this->assertEquals('2022-01-24T00:00:00.000Z', end($result)['published_at']);
+	}
 }

--- a/tests/wpunit/ResourceTest.php
+++ b/tests/wpunit/ResourceTest.php
@@ -41,16 +41,16 @@ class ResourceTest extends \Codeception\TestCase\WPTestCase
 		// (and therefore the ConvertKit APIs) to perform tests on.
 		$this->resource->resources = [
 			2780977 => [
-				'id'         	=> 2780977,
-				'name'       	=> 'Z Name', // 'name' used by forms, landing pages, products, tags.
-				'title'		 	=> 'Z Name', // 'title' used by posts.
-				'published_at' 	=> '2022-01-24T00:00:00.000Z', // used by posts.
+				'id'           => 2780977,
+				'name'         => 'Z Name', // 'name' used by forms, landing pages, products, tags.
+				'title'        => 'Z Name', // 'title' used by posts.
+				'published_at' => '2022-01-24T00:00:00.000Z', // used by posts.
 			],
 			2765139 => [
-				'id'         	=> 2765139,
-				'name'       	=> 'A Name', // 'name' used by forms, landing pages, products, tags.
-				'title'		 	=> 'A Name', // 'title' used by posts.
-				'published_at' 	=> '2022-05-03T14:51:50.000Z', // used by posts.
+				'id'           => 2765139,
+				'name'         => 'A Name', // 'name' used by forms, landing pages, products, tags.
+				'title'        => 'A Name', // 'title' used by posts.
+				'published_at' => '2022-05-03T14:51:50.000Z', // used by posts.
 			],
 		];
 
@@ -72,8 +72,8 @@ class ResourceTest extends \Codeception\TestCase\WPTestCase
 	/**
 	 * Tests that the get() function returns resources in alphabetical ascending order
 	 * by default.
-	 * 
-	 * @since 	1.3.1
+	 *
+	 * @since   1.3.1
 	 */
 	public function testGet()
 	{
@@ -95,8 +95,8 @@ class ResourceTest extends \Codeception\TestCase\WPTestCase
 	/**
 	 * Tests that the get() function returns resources in alphabetical ascending order
 	 * when a valid order_by setting is defined.
-	 * 
-	 * @since 	1.3.1
+	 *
+	 * @since   1.3.1
 	 */
 	public function testGetWithValidOrderBy()
 	{
@@ -121,8 +121,8 @@ class ResourceTest extends \Codeception\TestCase\WPTestCase
 	/**
 	 * Tests that the get() function returns resources in their original order
 	 * when populated with Forms and an invalid order_by value is specified.
-	 * 
-	 * @since 	1.3.1
+	 *
+	 * @since   1.3.1
 	 */
 	public function testGetWithInvalidOrderBy()
 	{
@@ -147,14 +147,14 @@ class ResourceTest extends \Codeception\TestCase\WPTestCase
 	/**
 	 * Tests that the get() function returns resources in alphabetical descending order
 	 * when a valid order_by setting is defined.
-	 * 
-	 * @since 	1.3.1
+	 *
+	 * @since   1.3.1
 	 */
 	public function testGetWithValidOrder()
 	{
 		// Define order to be descending.
 		$this->resource->order_by = 'name';
-		$this->resource->order = 'desc';
+		$this->resource->order    = 'desc';
 
 		// Call resource class' get() function.
 		$result = $this->resource->get();
@@ -174,14 +174,14 @@ class ResourceTest extends \Codeception\TestCase\WPTestCase
 	/**
 	 * Tests that the get() function returns resources in date descending order
 	 * when a valid order and order_by settings are defined.
-	 * 
-	 * @since 	1.3.1
+	 *
+	 * @since   1.3.1
 	 */
 	public function testGetWithValidOrderByAndOrder()
 	{
 		// Define order to be descending.
 		$this->resource->order_by = 'published_at';
-		$this->resource->order = 'desc';
+		$this->resource->order    = 'desc';
 
 		// Call resource class' get() function.
 		$result = $this->resource->get();

--- a/tests/wpunit/ResourceTest.php
+++ b/tests/wpunit/ResourceTest.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Tests for the ConvertKit_Resource class.
+ *
+ * @since   1.3.1
+ */
+class ResourceTest extends \Codeception\TestCase\WPTestCase
+{
+	/**
+	 * The testing implementation.
+	 *
+	 * @var \WpunitTester.
+	 */
+	protected $tester;
+
+	/**
+	 * Holds the ConvertKit Resource class.
+	 *
+	 * @since   1.3.1
+	 *
+	 * @var     ConvertKit_Resource
+	 */
+	private $resource;
+
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since   1.3.1
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		// Include class from /src to test.
+		require_once 'src/class-convertkit-resource.php';
+
+		// Initialize the classes we want to test.
+		$this->resource = new ConvertKit_Resource();
+	}
+
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since   1.3.1
+	 */
+	public function tearDown(): void
+	{
+		// Destroy the classes we tested.
+		unset($this->api);
+		unset($this->api_no_data);
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Tests that the get() function returns resources in alphabetical order when
+	 * populated with Forms.
+	 * 
+	 * @since 	1.3.1
+	 */
+	public function testGetForms()
+	{
+		// Mock the data that the resource class would fetch from the WordPress options table
+		// (and therefore the ConvertKit API), deliberately in a non-alphabetical order.
+		$this->resource->resources = [
+			2765139 => [
+				'id'         => 2765139,
+				'name'       => 'Page Form',
+			],
+			2780977 => [
+				'id'         => 2780977,
+				'name'       => 'Modal Form',
+			]
+		];
+
+		// Call resource class' get() function.
+		$result = $this->resource->get();
+
+		// Assert result is an array.
+		$this->assertIsArray($result);
+
+		// Assert array keys are preserved.
+		$this->assertArrayHasKey(array_key_first($this->resource->resources), $result);
+		$this->assertArrayHasKey(array_key_last($this->resource->resources), $result);
+
+		// Assert order of data is alphabetical.
+		$this->assertEquals(reset($this->resource->resources)['name'], end($result)['name']);
+		$this->assertEquals(end($this->resource->resources)['name'], reset($result)['name']);
+	}
+
+	/**
+	 * Tests that the get() function returns resources in their original order
+	 * when populated with Forms and an invalid order_by value is specified.
+	 * 
+	 * @since 	1.3.1
+	 */
+	public function testGetFormsWithInvalidOrderBy()
+	{
+		// Mock the data that the resource class would fetch from the WordPress options table
+		// (and therefore the ConvertKit API), deliberately in a non-alphabetical order.
+		$this->resource->resources = [
+			2765139 => [
+				'id'         => 2765139,
+				'name'       => 'Page Form',
+			],
+			2780977 => [
+				'id'         => 2780977,
+				'name'       => 'Modal Form',
+			],
+		];
+
+		// Define the sort order with an invalid value.
+		$this->resource->order_by = 'invalid_key';
+
+		// Call resource class' get() function.
+		$result = $this->resource->get();
+
+		// Assert result is an array, and no error occured.
+		$this->assertIsArray($result);
+
+		// Assert array keys are preserved.
+		$this->assertArrayHasKey(array_key_first($this->resource->resources), $result);
+		$this->assertArrayHasKey(array_key_last($this->resource->resources), $result);
+	}
+
+}


### PR DESCRIPTION
## Summary

API requests return resources (forms, landing pages, posts, products, tags) in the expected alphabetical order (or published date for broadcasts), which are then cached in our ConvertKit Plugins:
<img width="444" alt="Screenshot 2023-01-23 at 16 30 11" src="https://user-images.githubusercontent.com/1462305/214094741-e77d28a5-8db6-4b1f-83b0-e7847b6869c6.png">

However, [this reported issue](https://wordpress.org/support/topic/convertkit-tags-in-woocommerce-not-in-alphabetical-order/) indicates that this might not always happen. It's also not good practice to assume the order of data from the API is correct.

This PR adds sort options to cached resources when the `get()` function is used,  based on the resource's `order_by` and `order` properties, which default to `name` in ascending order.

Where an invalid `order_by` is defined, no sorting takes place.

## Testing

- `ResourceTest`: Tests the `get()` function in the resource class to confirm that data is returned in the expected order, based on the supplied `order_by` and `order` properties.  Data is mocked deliberately in incorrect sorting to confirm correct working functionality.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)