### PR TITLE
Sort Resources on Refresh

### DIFF
--- a/src/class-convertkit-resource.php
+++ b/src/class-convertkit-resource.php
@@ -356,8 +356,8 @@ class ConvertKit_Resource {
 		 */
 		do_action( 'convertkit_resource_refreshed_' . $this->type, $results );
 
-		// Return resources.
-		return $results;
+		// Return resources, honoring the order_by and order properties.
+		return $this->get();
 
 	}
 

--- a/src/class-convertkit-resource.php
+++ b/src/class-convertkit-resource.php
@@ -141,6 +141,11 @@ class ConvertKit_Resource {
 		// with different order_by and order properties are supported.
 		$resources = $this->resources;
 
+		// Don't attempt sorting if no resources exist.
+		if ( ! $this->exist() ) {
+			return $resources;
+		}
+
 		// Don't attempt sorting if the order_by property doesn't exist as a key
 		// in the API response.
 		if ( ! array_key_exists( $this->order_by, reset( $resources ) ) ) {


### PR DESCRIPTION
## Summary

- Honor `order_by` and `order` properties when returning resources called via `refresh()`, by using `get()` instead of returning the unmodified resources array.
- Sanity check that resources exist in `get()` before attempting to sort them.

## Testing

Existing tests pass.  Plugins must include tests for each resource class (e.g. `ConvertKit_Resource_Tags`) on refresh, to confirm working functionality.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)