### PR TITLE
Reduce calls to `refresh()` on API error

### DIFF
--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -1041,7 +1041,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$result = $this->api->get_all_posts(2); // Number of posts to fetch in each request within the function.
 		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertIsArray($result);
-		$this->assertCount(4, $result);
+		$this->assertCount(3, $result);
 		$this->assertArrayHasKey('id', reset($result));
 		$this->assertArrayHasKey('title', reset($result));
 		$this->assertArrayHasKey('url', reset($result));


### PR DESCRIPTION
## Summary

Prevents multiple calls to `refresh()` on resources when e.g. an invalid API key has been specified, by storing the last query time prior to returning the API resultset.  This last query time will then ensure refreshing cached resources does not take place until either:
- the cache period expires,
- the user fixes the issue (e.g. enters valid API credentials in the Plugin's settings screen),
- the user forcibly refreshes resources using a Plugin's refresh button

See [this PR](https://github.com/ConvertKit/convertkit-wordpress/pull/435) for an example implementation in a Plugin, and the performance improvements as a result.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)