### PR TITLE
API: Include HTTP Response Code in `WP_Error`

### DIFF
--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -1719,7 +1719,11 @@ class ConvertKit_API {
 			case 429:
 				// If retry on rate limit hit is disabled, return a WP_Error.
 				if ( ! $retry_if_rate_limit_hit ) {
-					return new WP_Error( 'convertkit_api_error', $this->get_error_message( 'request_rate_limit_exceeded' ) );
+					return new WP_Error(
+						'convertkit_api_error',
+						$this->get_error_message( 'request_rate_limit_exceeded' ),
+						$http_response_code
+					);
 				}
 
 				// Retry the request a final time, waiting 2 seconds before.
@@ -1728,23 +1732,39 @@ class ConvertKit_API {
 
 			// Internal server error.
 			case 500:
-				return new WP_Error( 'convertkit_api_error', $this->get_error_message( 'request_internal_server_error' ) );
+				return new WP_Error(
+					'convertkit_api_error',
+					$this->get_error_message( 'request_internal_server_error' ),
+					$http_response_code
+				);
 
 			// Bad gateway.
 			case 502:
-				return new WP_Error( 'convertkit_api_error', $this->get_error_message( 'request_bad_gateway' ) );
+				return new WP_Error(
+					'convertkit_api_error',
+					$this->get_error_message( 'request_bad_gateway' ),
+					$http_response_code
+				);
 		}
 
 		// If the response is null, json_decode() failed as the body could not be decoded.
 		if ( is_null( $response ) ) {
 			$this->log( 'API: Error: ' . sprintf( $this->get_error_message( 'response_type_unexpected' ), $body ) );
-			return new WP_Error( 'convertkit_api_error', sprintf( $this->get_error_message( 'response_type_unexpected' ), $body ) );
+			return new WP_Error(
+				'convertkit_api_error',
+				sprintf( $this->get_error_message( 'response_type_unexpected' ), $body ),
+				$http_response_code
+			);
 		}
 
 		// If an error message or code exists in the response, return a WP_Error.
 		if ( isset( $response['error'] ) ) {
 			$this->log( 'API: Error: ' . $response['error'] . ': ' . $response['message'] );
-			return new WP_Error( 'convertkit_api_error', $response['error'] . ': ' . $response['message'] );
+			return new WP_Error(
+				'convertkit_api_error',
+				$response['error'] . ': ' . $response['message'],
+				$http_response_code
+			);
 		}
 
 		return $response;

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -63,6 +63,21 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
+	 * Test that a 401 unauthorized error gracefully returns a WP_Error.
+	 *
+	 * @since   1.3.2
+	 */
+	public function test401Unauthorized()
+	{
+		$api    = new ConvertKit_API('fakeApiKey', 'fakeApiSecret');
+		$result = $api->account();
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+		$this->assertEquals($result->get_error_message(), 'Authorization Failed: API Key not valid');
+		$this->assertEquals($result->get_error_data($result->get_error_code()), 401);
+	}
+
+	/**
 	 * Test that a 429 internal server error gracefully returns a WP_Error.
 	 *
 	 * @since   1.0.0
@@ -75,6 +90,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
 		$this->assertEquals($result->get_error_message(), 'ConvertKit API Error: Rate limit hit.');
+		$this->assertEquals($result->get_error_data($result->get_error_code()), 429);
 	}
 
 	/**
@@ -90,6 +106,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
 		$this->assertEquals($result->get_error_message(), 'ConvertKit API Error: Internal server error.');
+		$this->assertEquals($result->get_error_data($result->get_error_code()), 500);
 	}
 
 	/**
@@ -105,6 +122,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
 		$this->assertEquals($result->get_error_message(), 'ConvertKit API Error: Bad gateway.');
+		$this->assertEquals($result->get_error_data($result->get_error_code()), 502);
 	}
 
 	/**

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -1059,7 +1059,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$result = $this->api->get_all_posts(2); // Number of posts to fetch in each request within the function.
 		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertIsArray($result);
-		$this->assertCount(4, $result);
+		$this->assertCount(3, $result);
 		$this->assertArrayHasKey('id', reset($result));
 		$this->assertArrayHasKey('title', reset($result));
 		$this->assertArrayHasKey('url', reset($result));


### PR DESCRIPTION
## Summary

Includes the HTTP response code in the data portion of the `WP_Error` object, when a call to the API results in an error.

This can then be used by Plugins by calling the `WP_Error` `get_error_data()` and `get_error_code()` functions, to provide more contextual error messages, such as in [this PR](https://github.com/ConvertKit/convertkit-wordpress/pull/436/files#diff-a35aa2f02cbc1b70dbe7febb0bc23c0173f8c7b6ac4e4eb224f1d41e41cc0bb0R230), where a link is displayed to the settings screen to resolve an invalid API key.

## Testing

- `APITest:test401Unauthorized`: Test that the expected HTTP response code and message is included in the WP_Error object

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)