### PR TITLE
Run tests against WordPress 6.2 beta 5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
     # Defines the WordPress and PHP Versions matrix to run tests on.
     strategy:
       matrix:
-        wp-versions: [ '6.2-beta4' ] #[ 'latest', '6.1.1' ]
+        wp-versions: [ '6.2-beta5' ] #[ 'latest', '6.1.1' ]
         php-versions: [ '7.4', '8.0', '8.1', '8.2' ] #[ '7.4', '8.0', '8.1', '8.2' ]
 
     # Steps to install, configure and run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
     # Defines the WordPress and PHP Versions matrix to run tests on.
     strategy:
       matrix:
-        wp-versions: [ 'latest' ] #[ 'latest', '6.1.1' ]
+        wp-versions: [ '6.2-beta4' ] #[ 'latest', '6.1.1' ]
         php-versions: [ '7.4', '8.0', '8.1', '8.2' ] #[ '7.4', '8.0', '8.1', '8.2' ]
 
     # Steps to install, configure and run tests

--- a/src/class-convertkit-resource.php
+++ b/src/class-convertkit-resource.php
@@ -57,7 +57,7 @@ class ConvertKit_Resource {
 	/**
 	 * Holds the resources from the ConvertKit API
 	 *
-	 * @var     WP_Error|array
+	 * @var     WP_Error|array|bool|null
 	 */
 	public $resources = array();
 
@@ -258,7 +258,7 @@ class ConvertKit_Resource {
 	 */
 	public function exist() {
 
-		if ( $this->resources === false ) { // @phpstan-ignore-line.
+		if ( $this->resources === false ) {
 			return false;
 		}
 


### PR DESCRIPTION
## Summary

Run tests against WordPress 6.2 beta 5

Also improves definition of resources for PHPStan 1.10 compatibility

## Testing

Existing tests pass

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)