### PR TITLE
Add Review Request notice view

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,6 +10,10 @@ parameters:
     paths:
         - src/
 
+    # Paths to exclude
+    excludePaths:
+        - src/views/
+
     # Location of WordPress Plugins for PHPStan to scan, building symbols.
     scanDirectories:
         - /home/runner/work/convertkit-wordpress-libraries/convertkit-wordpress-libraries/wordpress/wp-content/plugins

--- a/phpstan.neon.example
+++ b/phpstan.neon.example
@@ -10,6 +10,10 @@ parameters:
     paths:
         - src/
 
+    # Paths to exclude
+    excludePaths:
+        - src/views/
+
     # Location of WordPress Plugins for PHPStan to scan, building symbols.
     scanDirectories:
         - /Users/tim/Local Sites/convertkit-github/app/public/wp-content/plugins

--- a/src/class-convertkit-review-request.php
+++ b/src/class-convertkit-review-request.php
@@ -22,7 +22,7 @@ class ConvertKit_Review_Request {
 	 *
 	 * @var     string
 	 */
-	private $plugin_name; // @phpstan-ignore-line
+	private $plugin_name;
 
 	/**
 	 * Holds the Plugin slug.
@@ -34,22 +34,13 @@ class ConvertKit_Review_Request {
 	private $plugin_slug;
 
 	/**
-	 * Holds the Plugin path.
-	 *
-	 * @since   1.0.0
-	 *
-	 * @var     string
-	 */
-	private $plugin_path;
-
-	/**
 	 * Holds the text items to display on the review request notification.
-	 * 
-	 * @since 	1.3.4
-	 * 
-	 * @var 	bool|array
+	 *
+	 * @since   1.3.4
+	 *
+	 * @var     array
 	 */
-	private $text_items = false;
+	private $text_items;
 
 	/**
 	 * Holds the number of days after the Plugin requests a review to then
@@ -66,22 +57,21 @@ class ConvertKit_Review_Request {
 	 *
 	 * @since   1.0.0
 	 *
-	 * @param   string 		$plugin_name    Plugin Name (e.g. ConvertKit).
-	 * @param   string 		$plugin_slug    Plugin Slug (e.g. convertkit).
-	 * @param   string 		$plugin_path    Plugin Path.
+	 * @param   string $plugin_name    Plugin Name (e.g. ConvertKit).
+	 * @param   string $plugin_slug    Plugin Slug (e.g. convertkit).
+	 * @param   string $plugin_path    Plugin Path (unused, but kept for backward compat. with Plugins that include this argument).
 	 */
-	public function __construct( $plugin_name, $plugin_slug, $plugin_path ) {
+	public function __construct( $plugin_name, $plugin_slug, $plugin_path ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter, @phpstan-ignore-line
 
-		// Store the Plugin name, slug and path in the class.
+		// Store the Plugin name, slug and text items.
 		$this->plugin_name = $plugin_name;
 		$this->plugin_slug = $plugin_slug;
-		$this->plugin_path = $plugin_path;
-		$this->text_items = array(
-			'message' 		=> sprintf(
+		$this->text_items  = array(
+			'message'       => sprintf(
 				'We\'d be super grateful if you could spread the word about %s and give it a 5 star rating on WordPress?',
 				$this->plugin_name
 			),
-			'leave_review' 	=> 'Yes, leave review',
+			'leave_review'  => 'Yes, leave review',
 			'having_issues' => sprintf(
 				'No, I\'m having issues with %s',
 				$this->plugin_name
@@ -136,10 +126,10 @@ class ConvertKit_Review_Request {
 
 	/**
 	 * Returns the text to display at the start of the review request notification.
-	 * 
-	 * @since 	1.3.4
-	 * 
-	 * @return 	string
+	 *
+	 * @since   1.3.4
+	 *
+	 * @return  string
 	 */
 	public function get_message_text() {
 
@@ -154,10 +144,10 @@ class ConvertKit_Review_Request {
 
 	/**
 	 * Returns the text to display prompting the user to leave a review.
-	 * 
-	 * @since 	1.3.4
-	 * 
-	 * @return 	string
+	 *
+	 * @since   1.3.4
+	 *
+	 * @return  string
 	 */
 	public function get_leave_review_text() {
 
@@ -172,10 +162,10 @@ class ConvertKit_Review_Request {
 
 	/**
 	 * Returns the text to display if the user is having issues with the Plugin.
-	 * 
-	 * @since 	1.3.4
-	 * 
-	 * @return 	string
+	 *
+	 * @since   1.3.4
+	 *
+	 * @return  string
 	 */
 	public function get_having_issues_text() {
 

--- a/src/class-convertkit-review-request.php
+++ b/src/class-convertkit-review-request.php
@@ -43,6 +43,15 @@ class ConvertKit_Review_Request {
 	private $plugin_path;
 
 	/**
+	 * Holds the text items to display on the review request notification.
+	 * 
+	 * @since 	1.3.4
+	 * 
+	 * @var 	bool|array
+	 */
+	private $text_items = false;
+
+	/**
 	 * Holds the number of days after the Plugin requests a review to then
 	 * display the review notification in WordPress' Administration interface.
 	 *
@@ -57,16 +66,35 @@ class ConvertKit_Review_Request {
 	 *
 	 * @since   1.0.0
 	 *
-	 * @param   string $plugin_name    Plugin Name (e.g. ConvertKit).
-	 * @param   string $plugin_slug    Plugin Slug (e.g. convertkit).
-	 * @param   string $plugin_path    Plugin Path.
+	 * @param   string 		$plugin_name    Plugin Name (e.g. ConvertKit).
+	 * @param   string 		$plugin_slug    Plugin Slug (e.g. convertkit).
+	 * @param   string 		$plugin_path    Plugin Path.
+	 * @param   bool|array  $text_items 	Array of text items to display on the review request notification.
 	 */
-	public function __construct( $plugin_name, $plugin_slug, $plugin_path ) {
+	public function __construct( $plugin_name, $plugin_slug, $plugin_path, $text_items = false ) {
 
 		// Store the Plugin name, slug and path in the class.
 		$this->plugin_name = $plugin_name;
 		$this->plugin_slug = $plugin_slug;
 		$this->plugin_path = $plugin_path;
+
+		// If text items are defined, use them.
+		if ( is_array( $text_items ) ) {
+			$this->text_items = $text_items;
+		} else {
+			// Fallback to some sensible defaults. These won't be localized by WordPress.
+			$this->text_items = array(
+				'message' 		=> sprintf(
+					'We\'d be super grateful if you could spread the word about %s and give it a 5 star rating on WordPress?',
+					$this->plugin_name
+				),
+				'leave_review' 	=> 'Yes, leave review',
+				'having_issues' => sprintf(
+					'No, I\'m having issues with %s',
+					$this->plugin_name
+				),
+			);
+		}
 
 		// Register an AJAX action to dismiss the review.
 		add_action( 'wp_ajax_' . str_replace( '-', '_', $this->plugin_slug ) . '_dismiss_review', array( $this, 'dismiss_review' ) );
@@ -110,7 +138,61 @@ class ConvertKit_Review_Request {
 		}
 
 		// If here, display the request for a review.
-		include_once $this->plugin_path . '/views/backend/review/notice.php';
+		include_once 'views/review-request.php';
+
+	}
+
+	/**
+	 * Returns the text to display at the start of the review request notification.
+	 * 
+	 * @since 	1.3.4
+	 * 
+	 * @return 	string
+	 */
+	public function get_message_text() {
+
+		// Return blank string if message text doesn't exist in the array.
+		if ( ! array_key_exists( 'message', $this->text_items ) ) {
+			return '';
+		}
+
+		return $this->text_items['message'];
+
+	}
+
+	/**
+	 * Returns the text to display prompting the user to leave a review.
+	 * 
+	 * @since 	1.3.4
+	 * 
+	 * @return 	string
+	 */
+	public function get_leave_review_text() {
+
+		// Return blank string if leave review text doesn't exist in the array.
+		if ( ! array_key_exists( 'leave_review', $this->text_items ) ) {
+			return '';
+		}
+
+		return $this->text_items['leave_review'];
+
+	}
+
+	/**
+	 * Returns the text to display if the user is having issues with the Plugin.
+	 * 
+	 * @since 	1.3.4
+	 * 
+	 * @return 	string
+	 */
+	public function get_having_issues_text() {
+
+		// Return blank string if leave review text doesn't exist in the array.
+		if ( ! array_key_exists( 'having_issues', $this->text_items ) ) {
+			return '';
+		}
+
+		return $this->text_items['having_issues'];
 
 	}
 

--- a/src/class-convertkit-review-request.php
+++ b/src/class-convertkit-review-request.php
@@ -69,32 +69,24 @@ class ConvertKit_Review_Request {
 	 * @param   string 		$plugin_name    Plugin Name (e.g. ConvertKit).
 	 * @param   string 		$plugin_slug    Plugin Slug (e.g. convertkit).
 	 * @param   string 		$plugin_path    Plugin Path.
-	 * @param   bool|array  $text_items 	Array of text items to display on the review request notification.
 	 */
-	public function __construct( $plugin_name, $plugin_slug, $plugin_path, $text_items = false ) {
+	public function __construct( $plugin_name, $plugin_slug, $plugin_path ) {
 
 		// Store the Plugin name, slug and path in the class.
 		$this->plugin_name = $plugin_name;
 		$this->plugin_slug = $plugin_slug;
 		$this->plugin_path = $plugin_path;
-
-		// If text items are defined, use them.
-		if ( is_array( $text_items ) ) {
-			$this->text_items = $text_items;
-		} else {
-			// Fallback to some sensible defaults. These won't be localized by WordPress.
-			$this->text_items = array(
-				'message' 		=> sprintf(
-					'We\'d be super grateful if you could spread the word about %s and give it a 5 star rating on WordPress?',
-					$this->plugin_name
-				),
-				'leave_review' 	=> 'Yes, leave review',
-				'having_issues' => sprintf(
-					'No, I\'m having issues with %s',
-					$this->plugin_name
-				),
-			);
-		}
+		$this->text_items = array(
+			'message' 		=> sprintf(
+				'We\'d be super grateful if you could spread the word about %s and give it a 5 star rating on WordPress?',
+				$this->plugin_name
+			),
+			'leave_review' 	=> 'Yes, leave review',
+			'having_issues' => sprintf(
+				'No, I\'m having issues with %s',
+				$this->plugin_name
+			),
+		);
 
 		// Register an AJAX action to dismiss the review.
 		add_action( 'wp_ajax_' . str_replace( '-', '_', $this->plugin_slug ) . '_dismiss_review', array( $this, 'dismiss_review' ) );

--- a/src/views/review-request.php
+++ b/src/views/review-request.php
@@ -11,7 +11,7 @@
 <div class="notice notice-info is-dismissible review-<?php echo esc_attr( $this->plugin_slug ); ?>">
 	<p>
 		<?php
-		echo esc_html( $this->get_intro_text() );
+		echo esc_html( $this->get_message_text() );
 		?>
 	</p>
 	<p>
@@ -28,7 +28,7 @@
 			// Dismiss Review Notification.
 			$( 'div.review-<?php echo esc_attr( $this->plugin_slug ); ?>' ).on( 'click', 'a, button.notice-dismiss', function( e ) {
 
-				// Do request
+				// Do request.
 				$.post( 
 					ajaxurl, 
 					{
@@ -38,7 +38,7 @@
 					}
 				);
 
-				// Hide notice
+				// Hide notice.
 				$( 'div.review-<?php echo esc_attr( $this->plugin_slug ); ?>' ).hide();
 
 			} );

--- a/src/views/review-request.php
+++ b/src/views/review-request.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Notification output for a review request.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+?>
+
+<div class="notice notice-info is-dismissible review-<?php echo esc_attr( $this->plugin_slug ); ?>">
+	<p>
+		<?php
+		echo esc_html( $this->get_intro_text() );
+		?>
+	</p>
+	<p>
+		<a href="<?php echo esc_attr( $this->get_review_url() ); ?>" class="button button-primary" rel="noopener" target="_blank">
+			<?php echo esc_html( $this->get_leave_review_text() ); ?>
+		</a>
+		<a href="<?php echo esc_attr( $this->get_support_url() ); ?>" class="button" rel="noopener" target="_blank">
+			<?php echo esc_html( $this->get_having_issues_text() ); ?>
+		</a>
+	</p>
+
+	<script type="text/javascript">
+		jQuery( document ).ready( function( $ ) {
+			// Dismiss Review Notification.
+			$( 'div.review-<?php echo esc_attr( $this->plugin_slug ); ?>' ).on( 'click', 'a, button.notice-dismiss', function( e ) {
+
+				// Do request
+				$.post( 
+					ajaxurl, 
+					{
+						action: '<?php echo esc_attr( str_replace( '-', '_', $this->plugin_slug ) ); ?>_dismiss_review',
+					},
+					function( response ) {
+					}
+				);
+
+				// Hide notice
+				$( 'div.review-<?php echo esc_attr( $this->plugin_slug ); ?>' ).hide();
+
+			} );
+		} );
+	</script>
+</div>
+


### PR DESCRIPTION
## Summary

Adds the review request notice's PHP view file to this library, instead of referencing the view provided in each WordPress Plugin.

Each WordPress Plugin no longer needs to provide its own version of the `views/backend/review/notice.php`. [Example PR here](https://github.com/ConvertKit/convertkit-wordpress/pull/454) of how this works with the main ConvertKit Plugin.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)