### PR TITLE
Add docblock support for `WC_Logger`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,7 @@ jobs:
       DB_USER: root
       DB_PASS: root
       DB_HOST: localhost
+      INSTALL_PLUGINS: "woocommerce" # Don't include this repository's Plugin here.
       CONVERTKIT_API_KEY: ${{ secrets.CONVERTKIT_API_KEY }} # ConvertKit API Key, stored in the repository's Settings > Secrets
       CONVERTKIT_API_SECRET: ${{ secrets.CONVERTKIT_API_SECRET }} # ConvertKit API Secret, stored in the repository's Settings > Secrets
       CONVERTKIT_API_KEY_NO_DATA: ${{ secrets.CONVERTKIT_API_KEY_NO_DATA }} # ConvertKit API Key for ConvertKit account with no data, stored in the repository's Settings > Secrets
@@ -93,6 +94,11 @@ jobs:
       - name: Install WordPress
         working-directory: ${{ env.ROOT_DIR }}
         run: wp-cli core install --url=127.0.0.1 --title=ConvertKit --admin_user=admin --admin_password=password --admin_email=wordpress@convertkit.local
+
+      # env.INSTALL_PLUGINS is a list of Plugin slugs, space separated e.g. contact-form-7 woocommerce.
+      - name: Install Free Third Party WordPress Plugins
+        working-directory: ${{ env.ROOT_DIR }}
+        run: wp-cli plugin install ${{ env.INSTALL_PLUGINS }}
 
       # Install PHP version to run tests against.
       - name: Install PHP

--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -103,7 +103,7 @@ class ConvertKit_API {
 	/**
 	 * Holds the log class for writing to the log file
 	 *
-	 * @var bool|ConvertKit_Log
+	 * @var bool|ConvertKit_Log|WC_Logger
 	 */
 	public $log = false;
 


### PR DESCRIPTION
## Summary

Adds support for supplying a `WC_Logger` as a log property in the API class, as used in the [ConvertKit for WooCommerce Plugin](https://github.com/ConvertKit/convertkit-woocommerce/blob/main/includes/class-ckwc-api.php#L54).

This also resolves needing to [ignore this property](https://github.com/ConvertKit/convertkit-woocommerce/pull/149) in static analysis.

## Testing

Existing tests pass

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)