### PR TITLE
API: On error, check if a `message` key is included

### DIFF
--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -1773,10 +1773,17 @@ class ConvertKit_API {
 
 		// If an error message or code exists in the response, return a WP_Error.
 		if ( isset( $response['error'] ) ) {
-			$this->log( 'API: Error: ' . $response['error'] . ': ' . $response['message'] );
+			// Build the message.
+			$message = $response['error'];
+			if ( array_key_exists( 'message', $response ) ) {
+				$message .= ': ' . $response['message'];
+			}
+
+			// Log and return.
+			$this->log( 'API: Error: ' . $message );
 			return new WP_Error(
 				'convertkit_api_error',
-				$response['error'] . ': ' . $response['message'],
+				$message,
 				$http_response_code
 			);
 		}


### PR DESCRIPTION
## Summary

Checks if the API returns a `message` key, as it's not always included in an API error response - for example, when calling 
 the `subscriber_authentication/verify` API endpoint with an invalid token and invalid code:

![Screenshot 2023-05-24 at 13 34 42](https://github.com/ConvertKit/convertkit-wordpress-libraries/assets/1462305/d34ae21c-513d-42a2-acc6-5b9a62996f8e)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)