### PR TITLE
Add `get_by` method

### DIFF
--- a/src/class-convertkit-resource.php
+++ b/src/class-convertkit-resource.php
@@ -222,9 +222,9 @@ class ConvertKit_Resource {
 				unset( $resources[ $id ] );
 				continue;
 			}
-
+			
 			// Remove this resource if the value doesn't match.
-			if ( $resource[ $key ] !== $value ) {
+			if ( ! is_array( $value ) && $resource[ $key ] !== $value ) {
 				unset( $resources[ $id ] );
 				continue;
 			}

--- a/src/class-convertkit-resource.php
+++ b/src/class-convertkit-resource.php
@@ -146,26 +146,8 @@ class ConvertKit_Resource {
 			return $resources;
 		}
 
-		// Don't attempt sorting if the order_by property doesn't exist as a key
-		// in the API response.
-		if ( ! array_key_exists( $this->order_by, reset( $resources ) ) ) {
-			return $resources;
-		}
-
-		// Sort resources ascending by the order_by property.
-		uasort(
-			$resources,
-			function( $a, $b ) {
-				return strcmp( $a[ $this->order_by ], $b[ $this->order_by ] );
-			}
-		);
-
-		// Reverse the array if the results should be returned in descending order.
-		if ( $this->order === 'desc' ) {
-			$resources = array_reverse( $resources, true );
-		}
-
-		return $resources;
+		// Return resources sorted by order_by and order.
+		return $this->sort( $resources );
 
 	}
 
@@ -192,12 +174,12 @@ class ConvertKit_Resource {
 
 	/**
 	 * Returns resources where the resource's key matches the given value.
-	 * 
-	 * @since 	1.3.6
-	 * 
-	 * @param 	string 			$key 	Resource Key.
-	 * @param 	string|array 	$value 	Value(s).
-	 * @return 	bool|array
+	 *
+	 * @since   1.3.6
+	 *
+	 * @param   string       $key    Resource Key.
+	 * @param   string|array $value  Value(s).
+	 * @return  bool|array
 	 */
 	public function get_by( $key, $value ) {
 
@@ -222,7 +204,7 @@ class ConvertKit_Resource {
 				unset( $resources[ $id ] );
 				continue;
 			}
-			
+
 			// Remove this resource if the value doesn't match.
 			if ( ! is_array( $value ) && $resource[ $key ] !== $value ) {
 				unset( $resources[ $id ] );
@@ -234,6 +216,21 @@ class ConvertKit_Resource {
 		if ( empty( $resources ) ) {
 			return false;
 		}
+
+		// Return resources sorted by order_by and order.
+		return $this->sort( $resources );
+
+	}
+
+	/**
+	 * Sorts the given array of resources by the class' order_by and order properties.
+	 *
+	 * @since   1.3.6
+	 *
+	 * @param   array $resources  Resources.
+	 * @return  array               Resources
+	 */
+	public function sort( $resources ) {
 
 		// Don't attempt sorting if the order_by property doesn't exist as a key
 		// in the API response.

--- a/src/class-convertkit-resource.php
+++ b/src/class-convertkit-resource.php
@@ -190,6 +190,73 @@ class ConvertKit_Resource {
 
 	}
 
+	/**
+	 * Returns resources where the resource's key matches the given value.
+	 * 
+	 * @since 	1.3.6
+	 * 
+	 * @param 	string 			$key 	Resource Key.
+	 * @param 	string|array 	$value 	Value(s).
+	 * @return 	bool|array
+	 */
+	public function get_by( $key, $value ) {
+
+		// Don't mutate the underlying resources, so multiple calls to get()
+		// with different order_by and order properties are supported.
+		$resources = $this->resources;
+
+		// Don't attempt sorting if no resources exist.
+		if ( ! $this->exist() ) {
+			return $resources;
+		}
+
+		foreach ( $resources as $id => $resource ) {
+			// Remove this resource if it doesn't have the array key.
+			if ( ! array_key_exists( $key, $resource ) ) {
+				unset( $resources[ $id ] );
+				continue;
+			}
+
+			// Remove this resource if the value is an array and none of the array values match.
+			if ( is_array( $value ) && ! in_array( $resource[ $key ], $value, true ) ) {
+				unset( $resources[ $id ] );
+				continue;
+			}
+
+			// Remove this resource if the value doesn't match.
+			if ( $resource[ $key ] !== $value ) {
+				unset( $resources[ $id ] );
+				continue;
+			}
+		}
+
+		// If the array is empty, return false.
+		if ( empty( $resources ) ) {
+			return false;
+		}
+
+		// Don't attempt sorting if the order_by property doesn't exist as a key
+		// in the API response.
+		if ( ! array_key_exists( $this->order_by, reset( $resources ) ) ) {
+			return $resources;
+		}
+
+		// Sort resources ascending by the order_by property.
+		uasort(
+			$resources,
+			function( $a, $b ) {
+				return strcmp( $a[ $this->order_by ], $b[ $this->order_by ] );
+			}
+		);
+
+		// Reverse the array if the results should be returned in descending order.
+		if ( $this->order === 'desc' ) {
+			$resources = array_reverse( $resources, true );
+		}
+
+		return $resources;
+
+	}
 
 	/**
 	 * Returns a paginated subset of resources, including whether

--- a/tests/wpunit/ResourceTest.php
+++ b/tests/wpunit/ResourceTest.php
@@ -197,4 +197,55 @@ class ResourceTest extends \Codeception\TestCase\WPTestCase
 		$this->assertEquals('2022-05-03T14:51:50.000Z', reset($result)['published_at']);
 		$this->assertEquals('2022-01-24T00:00:00.000Z', end($result)['published_at']);
 	}
+
+	/**
+	 * Tests that the get_by() function returns the matching resource when queried
+	 * by name.
+	 *
+	 * @since   1.3.6
+	 */
+	public function testGetBy()
+	{
+		// Call resource class' get_by() function.
+		$result = $this->resource->get_by('name', 'Z Name');
+
+		// Assert result is an array.
+		$this->assertIsArray($result);
+
+		// Assert one item was returned.
+		$this->assertCount(1, $result);
+
+		// Assert array keys are preserved.
+		$this->assertArrayHasKey(array_key_first($this->resource->resources), $result);
+
+		// Assert resource is the one we requested.
+		$this->assertEquals('Z Name', reset($result)[ $this->resource->order_by ]);
+	}
+
+	/**
+	 * Tests that the get_by() function returns the matching resources when queried
+	 * by multiple values.
+	 *
+	 * @since   1.3.6
+	 */
+	public function testGetByMultipleValues()
+	{
+		// Call resource class' get_by() function.
+		$result = $this->resource->get_by('name', [ 'A Name', 'Z Name' ]);
+
+		// Assert result is an array.
+		$this->assertIsArray($result);
+
+		// Assert two items were returned.
+		$this->assertCount(2, $result);
+
+		// Assert array keys are preserved.
+		$this->assertArrayHasKey(array_key_first($this->resource->resources), $result);
+		$this->assertArrayHasKey(array_key_last($this->resource->resources), $result);
+
+		// Assert order of data is in ascending alphabetical order.
+		$this->assertEquals('A Name', reset($result)[ $this->resource->order_by ]);
+		$this->assertEquals('Z Name', end($result)[ $this->resource->order_by ]);
+	}
+
 }


### PR DESCRIPTION
## Summary

Adds a `get_by` method, to return resources by a key and value(s) - for example, [fetching non-inline forms](https://github.com/ConvertKit/convertkit-wordpress/pull/490).

## Testing

- `ResourceTest:testGetBy`: Get a resource by its name, confirming the expected resource is returned.
- `ResourceTest:testGetByMultipleValues`: Get resources matching two names, confirming the expected resources are returned.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)