### PR TITLE
Upgrade to WordPress Coding Standards v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,7 @@
         "codeception/module-filesystem": "^1.0",                                   
         "codeception/module-cli": "^1.0",                                          
         "codeception/util-universalframework": "^1.0",
-        "squizlabs/php_codesniffer": "3.*",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-        "wp-coding-standards/wpcs": "*",
+        "wp-coding-standards/wpcs": "^3.0.0",
         "phpstan/phpstan": "^1.7",
         "szepeviktor/phpstan-wordpress": "^1.0"
     },

--- a/phpcs.tests.xml
+++ b/phpcs.tests.xml
@@ -2,6 +2,13 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP_CodeSniffer" xsi:noNamespaceSchemaLocation="phpcs.xsd">
     <description>Coding Standards for Tests</description>
 
+    <!-- Inspect files in the /tests folder -->
+    <file>tests</file>
+
+    <!-- Run in verbose mode and specify the precise rule that failed in output -->
+    <arg value="sv"/>
+    <arg name="colors"/>
+
     <!-- Check that code meets WordPress-Extra standards. -->
     <rule ref="WordPress-Extra">
         <!-- Don't use yoda conditions -->
@@ -15,26 +22,28 @@
         <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterOpenParenthesis" />
         <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.ExtraSpaceAfterCloseParenthesis" />
         <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterOpen" />
+        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingBeforeClose" />
         <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceBeforeCloseParenthesis" />
         <exclude name="Generic.Classes.OpeningBraceSameLine.BraceOnNewLine" />
         <exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie.BraceOnNewLine" />
         <exclude name="PEAR.Functions.FunctionCallSignature.SpaceBeforeOpenBracket" />
         <exclude name="PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket" />
         <exclude name="PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket" />
+        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction" />
 
         <!-- _before() and _passed() must use underscores in Codeception -->
         <exclude name="PSR2.Methods.MethodDeclaration.Underscore" />
 
         <!-- Permit [] instead of array() -->
-        <exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
-        
+        <exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />
+
         <!-- We might use some datetime functions for tests -->
         <exclude name="WordPress.DateTime.RestrictedFunctions" />
 
         <!-- Handles false positives where Coding Standards thinks we did something wrong when we're just checking for e.g. a stylesheet -->
         <exclude name="WordPress.WP.EnqueuedResources" />
         <exclude name="WordPress.PHP.DiscouragedPHPFunctions" />
-        <exclude name="WordPress.WP.CapitalPDangit.Misspelled" />
+        <exclude name="WordPress.WP.CapitalPDangit.MisspelledInText" />
     </rule>
 
     <!-- Check that code is documented to WordPress Standards. -->

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -30,6 +30,8 @@
 		<exclude name="WordPress.Security.EscapeOutput"/>
 		-->
 		<exclude name="WordPress.PHP.YodaConditions" />
+		<exclude name="PSR2.Methods.FunctionClosingBrace.SpacingBeforeClose" />
+		<exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody" />
 	</rule>
 
 	<!-- Check that code is documented to WordPress Standards. -->

--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -1506,12 +1506,12 @@ class ConvertKit_API {
 	 *
 	 * @since   1.0.0
 	 *
-	 * @param   string $string     Possible JSON String.
-	 * @return  bool                Is JSON String.
+	 * @param   string $json_string     Possible JSON String.
+	 * @return  bool                    Is JSON String.
 	 */
-	private function is_json( $string ) {
+	private function is_json( $json_string ) {
 
-		json_decode( $string );
+		json_decode( $json_string );
 		return json_last_error() === JSON_ERROR_NONE;
 
 	}

--- a/src/class-convertkit-log.php
+++ b/src/class-convertkit-log.php
@@ -144,7 +144,7 @@ class ConvertKit_Log {
 	 */
 	public function delete() {
 
-		unlink( $this->get_filename() );
+		wp_delete_file( $this->get_filename() );
 
 	}
 

--- a/src/class-convertkit-resource.php
+++ b/src/class-convertkit-resource.php
@@ -241,7 +241,7 @@ class ConvertKit_Resource {
 		// Sort resources ascending by the order_by property.
 		uasort(
 			$resources,
-			function( $a, $b ) {
+			function ( $a, $b ) {
 				return strcmp( $a[ $this->order_by ], $b[ $this->order_by ] );
 			}
 		);

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -1059,7 +1059,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$result = $this->api->get_all_posts(2); // Number of posts to fetch in each request within the function.
 		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertIsArray($result);
-		$this->assertCount(3, $result);
+		$this->assertCount(4, $result);
 		$this->assertArrayHasKey('id', reset($result));
 		$this->assertArrayHasKey('title', reset($result));
 		$this->assertArrayHasKey('url', reset($result));

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -1432,7 +1432,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$result = $this->api->get_landing_page_html($_ENV['CONVERTKIT_API_LANDING_PAGE_URL']);
 		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertStringContainsString('<form method="POST" action="https://app.convertkit.com/forms/' . $_ENV['CONVERTKIT_API_LANDING_PAGE_ID'] . '/subscriptions" data-sv-form="' . $_ENV['CONVERTKIT_API_LANDING_PAGE_ID'] . '" data-uid="99f1db6843" class="formkit-form"', $result);
-
 	}
 
 	/**

--- a/tests/wpunit/ResourceTest.php
+++ b/tests/wpunit/ResourceTest.php
@@ -53,7 +53,6 @@ class ResourceTest extends \Codeception\TestCase\WPTestCase
 				'published_at' => '2022-05-03T14:51:50.000Z', // used by posts.
 			],
 		];
-
 	}
 
 	/**
@@ -247,5 +246,4 @@ class ResourceTest extends \Codeception\TestCase\WPTestCase
 		$this->assertEquals('A Name', reset($result)[ $this->resource->order_by ]);
 		$this->assertEquals('Z Name', end($result)[ $this->resource->order_by ]);
 	}
-
 }


### PR DESCRIPTION
## Summary

Applies changes per the upgrade guide [here](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Upgrade-Guide-to-WordPressCS-3.0.0-for-Developers-of-external-standards), to support `3.0.0` of the WordPress Coding Standards rulesets, released August 21st.

This covers:
- Not using reserved keywords `$string` in varaibles
- Spacing for anonymous functions
- Renaming some exclusion rules as they have been renamed in WordPress Coding Standards `3.0.0`

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)