### PR TITLE
Add `create_broadcast` and `delete_broadcast` methods

### DIFF
--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -861,7 +861,7 @@ class ConvertKit_API {
 		}
 
 		// If the post isn't public, remove some params that don't apply.
-		if ( ! $public ) {
+		if ( ! $is_public ) {
 			unset( $params['published_at'], $params['thumbnail_alt'], $params['thumbnail_url'] );
 		}
 

--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -824,7 +824,7 @@ class ConvertKit_API {
 	 *
 	 * @see https://developers.convertkit.com/#create-a-broadcast
 	 *
-	 * @return false|object
+	 * @return WP_Error|array
 	 */
 	public function broadcast_create(
 		string $subject = '',

--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -898,7 +898,7 @@ class ConvertKit_API {
 	 * @since   1.3.9
 	 *
 	 * @param   int $broadcast_id   Broadcast ID.
-	 * @return  WP_Error|array
+	 * @return  WP_Error|null
 	 */
 	public function broadcast_delete( $broadcast_id ) {
 
@@ -936,6 +936,7 @@ class ConvertKit_API {
 		 */
 		do_action( 'convertkit_api_broadcast_delete_success', $response, $broadcast_id );
 
+		// Response will be null if successful.
 		return $response;
 
 	}
@@ -2000,8 +2001,8 @@ class ConvertKit_API {
 				);
 		}
 
-		// If the response is null, json_decode() failed as the body could not be decoded.
-		if ( is_null( $response ) ) {
+		// If the response is null for a non-DELETE method, json_decode() failed as the body could not be decoded.
+		if ( is_null( $response ) && $method !== 'delete' ) {
 			$this->log( 'API: Error: ' . sprintf( $this->get_error_message( 'response_type_unexpected' ), $body ) );
 			return new WP_Error(
 				'convertkit_api_error',

--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -175,7 +175,7 @@ class ConvertKit_API {
 			'unsubscribe_email_empty'                     => __( 'unsubscribe(): the email parameter is empty.', 'convertkit' ),
 
 			// broadcast_delete().
-			'broadcast_delete_broadcast_id_empty'		  => __( 'broadcast_delete(): the broadcast_is parameter is empty.', 'convertkit' ),
+			'broadcast_delete_broadcast_id_empty'		  => __( 'broadcast_delete(): the broadcast_id parameter is empty.', 'convertkit' ),
 
 			// get_all_posts().
 			'get_all_posts_posts_per_request_bound_too_low' => __( 'get_all_posts(): the posts_per_request parameter must be equal to or greater than 1.', 'convertkit' ),

--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -174,6 +174,9 @@ class ConvertKit_API {
 			// unsubscribe_email().
 			'unsubscribe_email_empty'                     => __( 'unsubscribe(): the email parameter is empty.', 'convertkit' ),
 
+			// broadcast_delete().
+			'broadcast_delete_broadcast_id_empty'		  => __( 'broadcast_delete(): the broadcast_is parameter is empty.', 'convertkit' ),
+
 			// get_all_posts().
 			'get_all_posts_posts_per_request_bound_too_low' => __( 'get_all_posts(): the posts_per_request parameter must be equal to or greater than 1.', 'convertkit' ),
 			'get_all_posts_posts_per_request_bound_too_high' => __( 'get_all_posts(): the posts_per_request parameter must be equal to or less than 50.', 'convertkit' ),
@@ -883,6 +886,55 @@ class ConvertKit_API {
 		 * @param   array   $params     Request parameters.
 		 */
 		do_action( 'convertkit_api_broadcast_create_success', $response, $params );
+
+		// Return broadcast.
+		return $response['broadcast'];
+
+	}
+
+	/**
+	 * Deletes a Broadcast.
+	 *
+	 * @since   1.3.9
+	 *
+	 * @param   int $broadcast_id   Broadcast ID.
+	 * @return  WP_Error|array
+	 */
+	public function broadcast_delete( $broadcast_id ) {
+
+		$this->log( 'API: broadcast_delete(): [ broadcast_id: ' . $broadcast_id . ']' );
+
+		// Sanitize some parameters.
+		$broadcast_id = absint( $broadcast_id );
+
+		// Return error if no Broadcast ID is specified.
+		if ( empty( $broadcast_id ) ) {
+			return new WP_Error( 'convertkit_api_error', $this->get_error_message( 'broadcast_delete_broadcast_id_empty' ) );
+		}
+
+		// Build request parameters.
+		$params = array(
+			'api_secret' => $this->api_secret,
+		);
+
+		// Send request.
+		$response = $this->delete( 'broadcasts/' . $broadcast_id, $params );
+
+		// If an error occured, log and return it now.
+		if ( is_wp_error( $response ) ) {
+			$this->log( 'API: broadcast_delete(): Error: ' . $response->get_error_message() );
+			return $response;
+		}
+
+		/**
+		 * Runs actions immediately after the broadcast was deleted.
+		 *
+		 * @since   1.0.0
+		 *
+		 * @param   array   $response       API Response
+		 * @param   int     $broadcast_id   Broadcast ID
+		 */
+		do_action( 'convertkit_api_broadcast_delete_success', $response, $broadcast_id );
 
 		return $response;
 

--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -1856,6 +1856,21 @@ class ConvertKit_API {
 	}
 
 	/**
+	 * Performs a DELETE request.
+	 *
+	 * @since  1.3.9
+	 *
+	 * @param   string $endpoint       API Endpoint.
+	 * @param   array  $params         Params.
+	 * @return  WP_Error|array
+	 */
+	private function delete( $endpoint, $params ) {
+
+		return $this->request( $endpoint, 'delete', $params, true );
+
+	}
+
+	/**
 	 * Main function which handles sending requests to the API using WordPress functions.
 	 *
 	 * @since   1.0.0
@@ -1901,6 +1916,22 @@ class ConvertKit_API {
 					$this->get_api_url( $endpoint ),
 					array(
 						'method'          => 'PUT',
+						'Accept-Encoding' => 'gzip',
+						'headers'         => array(
+							'Content-Type' => 'application/json; charset=utf-8',
+						),
+						'body'            => wp_json_encode( $params ),
+						'timeout'         => $this->get_timeout(),
+						'user-agent'      => $this->get_user_agent(),
+					)
+				);
+				break;
+
+			case 'delete':
+				$result = wp_remote_request(
+					$this->get_api_url( $endpoint ),
+					array(
+						'method'          => 'DELETE',
 						'Accept-Encoding' => 'gzip',
 						'headers'         => array(
 							'Content-Type' => 'application/json; charset=utf-8',

--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -931,8 +931,8 @@ class ConvertKit_API {
 		 *
 		 * @since   1.0.0
 		 *
-		 * @param   array   $response       API Response
-		 * @param   int     $broadcast_id   Broadcast ID
+		 * @param   null|array   $response       API Response
+		 * @param   int          $broadcast_id   Broadcast ID
 		 */
 		do_action( 'convertkit_api_broadcast_delete_success', $response, $broadcast_id );
 
@@ -1863,7 +1863,7 @@ class ConvertKit_API {
 	 *
 	 * @param   string $endpoint       API Endpoint.
 	 * @param   array  $params         Params.
-	 * @return  WP_Error|array
+	 * @return  WP_Error|null
 	 */
 	private function delete( $endpoint, $params ) {
 
@@ -1880,7 +1880,7 @@ class ConvertKit_API {
 	 * @param   string $method                  HTTP Method (optional).
 	 * @param   mixed  $params                  Params (array|boolean|string).
 	 * @param   bool   $retry_if_rate_limit_hit Retry request if rate limit hit.
-	 * @return  WP_Error|array
+	 * @return  WP_Error|array|null
 	 */
 	private function request( $endpoint, $method = 'get', $params = array(), $retry_if_rate_limit_hit = true ) {
 


### PR DESCRIPTION
## Summary

Adds `create_broadcast` and `delete_broadcast` methods, used in the main [ConvertKit WordPress Plugin](https://github.com/ConvertKit/convertkit-wordpress/pull/554).

## Testing

- `testCreateAndDeleteDraftBroadcast`: Test that creating and deleting a draft ConvertKit Broadcast works.
- `testCreateAndDeletePublicBroadcastWithValidDates`: Test that creating and deleting a published ConvertKit Broadcast works.
- `testDeleteBroadcastWithNoBroadcastID`: Test that the expected `WP_Error` is returned with the correct message when attempting to call `delete_broadcast` with no ConvertKit Broadcast ID
- `testDeleteBroadcastWithInvalidBroadcastID`: Test that the expected `WP_Error` is returned with the correct message when attempting to call `delete_broadcast` with an invalid ConvertKit Broadcast ID

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)