### PR TITLE
Add `tag_unsubscribe` method

### DIFF
--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -160,6 +160,11 @@ class ConvertKit_API {
 			'tag_subscribe_tag_id_empty'                  => __( 'tag_subscribe(): the tag_id parameter is empty.', 'convertkit' ),
 			'tag_subscribe_email_empty'                   => __( 'tag_subscribe(): the email parameter is empty.', 'convertkit' ),
 
+			// tag_unsubscribe().
+			'tag_unsubscribe_tag_id_empty'                => __( 'tag_unsubscribe(): the tag_id parameter is empty.', 'convertkit' ),
+			'tag_unsubscribe_email_empty'                 => __( 'tag_unsubscribe(): the email parameter is empty.', 'convertkit' ),
+			'tag_unsubscribe_email_invalid'               => __( 'tag_unsubscribe(): the email parameter is not a valid email address.', 'convertkit' ),
+
 			// get_subscriber_by_email().
 			'get_subscriber_by_email_email_empty'         => __( 'get_subscriber_by_email(): the email parameter is empty.', 'convertkit' ),
 			/* translators: Email Address */
@@ -592,6 +597,67 @@ class ConvertKit_API {
 		 * @param   mixed   $fields     Custom Fields (false|array).
 		 */
 		do_action( 'convertkit_api_tag_subscribe_success', $response, $tag_id, $email, $fields );
+
+		return $response;
+
+	}
+
+	/**
+	 * Removes a tag from the subscriber by their email address.
+	 *
+	 * @since   1.4.0
+	 *
+	 * @param   int    $tag_id     Tag ID.
+	 * @param   string $email      Email Address.
+	 * @return  WP_Error|array
+	 */
+	public function tag_unsubscribe( $tag_id, $email ) {
+
+		$this->log( 'API: tag_unsubscribe(): [ tag_id: ' . $tag_id . ', email: ' . $email . ']' );
+
+		// Sanitize some parameters.
+		$tag_id = absint( $tag_id );
+		$email  = trim( $email );
+
+		// Return error if no Tag ID or email address is specified.
+		if ( empty( $tag_id ) ) {
+			return new WP_Error( 'convertkit_api_error', $this->get_error_message( 'tag_unsubscribe_tag_id_empty' ) );
+		}
+		if ( empty( $email ) ) {
+			return new WP_Error( 'convertkit_api_error', $this->get_error_message( 'tag_unsubscribe_email_empty' ) );
+		}
+
+		// Return error if an invalid email is specified.
+		// Passing an invalid email to the API doesn't return an error, so we need to check here.
+		if ( ! filter_var( $email, FILTER_VALIDATE_EMAIL ) ) {
+			return new WP_Error( 'convertkit_api_error', $this->get_error_message( 'tag_unsubscribe_email_invalid' ) );
+		}
+
+		// Build request parameters.
+		$params = array(
+			'api_secret' => $this->api_secret,
+			'email'      => $email,
+		);
+
+		// Send request.
+		$response = $this->post( 'tags/' . $tag_id . '/unsubscribe', $params );
+
+		// If an error occured, log and return it now.
+		if ( is_wp_error( $response ) ) {
+			$this->log( 'API: tag_unsubscribe(): Error: ' . $response->get_error_message() );
+			return $response;
+		}
+
+		/**
+		 * Runs actions immediately after the email address was successfully unsubscribed from the tag.
+		 *
+		 * @since   1.4.0
+		 *
+		 * @param   array   $response   API Response
+		 * @param   int     $tag_id     Tag ID
+		 * @param   string  $email      Email Address
+		 */
+		do_action( 'convertkit_api_tag_unsubscribe_success', $response, $tag_id, $email );
 
 		return $response;
 

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -638,6 +638,105 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$this->assertEquals('Error updating subscriber: Email address is invalid', $result->get_error_message());
 	}
 
+
+	/**
+	 * Test that the `tag_unsubscribe()` function returns expected data
+	 * when valid parameters are provided.
+	 *
+	 * @since   1.4.0
+	 */
+	public function testTagUnsubscribe()
+	{
+		// Subscribe the email address to the tag.
+		$result = $this->api->tag_subscribe(
+			$_ENV['CONVERTKIT_API_TAG_ID'],
+			$_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']
+		);
+
+		// Unsubscribe the email address from the tag.
+		$result = $this->api->tag_unsubscribe(
+			$_ENV['CONVERTKIT_API_TAG_ID'],
+			$_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']
+		);
+
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', $result);
+		$this->assertArrayHasKey('name', $result);
+		$this->assertArrayHasKey('created_at', $result);
+		$this->assertEquals($result['name'], $_ENV['CONVERTKIT_API_TAG_NAME']);
+	}
+
+	/**
+	 * Test that the `tag_unsubscribe()` function returns a WP_Error
+	 * when an invalid $tag_id parameter is provided.
+	 *
+	 * @since   1.4.0
+	 */
+	public function testTagUnsubscribeWithInvalidTagID()
+	{
+		$result = $this->api->tag_unsubscribe(12345, $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']);
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+		$this->assertEquals('Not Found: The entity you were trying to find doesn\'t exist', $result->get_error_message());
+	}
+
+	/**
+	 * Test that the `tag_unsubscribe()` function returns a WP_Error
+	 * when an empty $tag_id parameter is provided.
+	 *
+	 * @since   1.4.0
+	 */
+	public function testTagUnsubscribeWithEmptyTagID()
+	{
+		$result = $this->api->tag_unsubscribe('', $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']);
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+		$this->assertEquals('tag_unsubscribe(): the tag_id parameter is empty.', $result->get_error_message());
+	}
+
+	/**
+	 * Test that the `tag_unsubscribe()` function returns a WP_Error
+	 * when an empty $email parameter is provided.
+	 *
+	 * @since   1.4.0
+	 */
+	public function testTagUnsubscribeWithEmptyEmail()
+	{
+		$result = $this->api->tag_unsubscribe($_ENV['CONVERTKIT_API_TAG_ID'], '');
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+		$this->assertEquals('tag_unsubscribe(): the email parameter is empty.', $result->get_error_message());
+	}
+
+	/**
+	 * Test that the `tag_unsubscribe()` function returns a WP_Error
+	 * when the $email parameter only consists of spaces.
+	 *
+	 * @since   1.4.0
+	 */
+	public function testTagUnsubscribeWithSpacesInEmail()
+	{
+		$result = $this->api->tag_unsubscribe($_ENV['CONVERTKIT_API_TAG_ID'], '     ');
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+		$this->assertEquals('tag_unsubscribe(): the email parameter is empty.', $result->get_error_message());
+	}
+
+	/**
+	 * Test that the `tag_unsubscribe()` function returns a WP_Error
+	 * when an invalid $email parameter is provided.
+	 *
+	 * @since   1.4.0
+	 */
+	public function testTagUnsubscribeWithInvalidEmail()
+	{
+		$result = $this->api->tag_unsubscribe($_ENV['CONVERTKIT_API_TAG_ID'], 'invalid-email-address');
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+		$this->assertEquals('tag_unsubscribe(): the email parameter is not a valid email address.', $result->get_error_message());
+	}
+
 	/**
 	 * Test that the `get_subscriber_by_email()` function returns expected data
 	 * when valid parameters are provided.
@@ -732,6 +831,12 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testGetSubscriberTags()
 	{
+		// Subscribe the email address to the tag.
+		$result = $this->api->tag_subscribe(
+			$_ENV['CONVERTKIT_API_TAG_ID'],
+			$_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']
+		);
+
 		$result = $this->api->get_subscriber_tags($_ENV['CONVERTKIT_API_SUBSCRIBER_ID']);
 		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertIsArray($result);


### PR DESCRIPTION
## Summary

Adds a `tag_unsubscribe` method to unsubscribe the given email address from the tag ID.

API Docs: https://developers.convertkit.com/#remove-tag-from-a-subscriber-by-email

## Testing

- `testTagUnsubscribe`: Test that the email address is unsubscribed from the given tag ID.
- `testTagUnsubscribeWithInvalidTagID`: Test that the expected error message is returned when an invalid tag ID is specified.
- `testTagUnsubscribeWithEmptyTagID`: Test that the expected error message is returned when an empty tag ID is specified.
- `testTagUnsubscribeWithEmptyEmail`:  Test that the expected error message is returned when an empty email address is specified.
- `testTagUnsubscribeWithSpacesInEmail`:  Test that the expected error message is returned when an email address comprising of spaces is specified.
- `testTagUnsubscribeWithInvalidEmail`:  Test that the expected error message is returned when an invalid email address is specified.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)