### PR TITLE
Landing Pages: Fix 403 Error

### DIFF
--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -1481,7 +1481,7 @@ class ConvertKit_API {
 	 * @param   string $url     URL of Landing Page.
 	 * @return  WP_Error|string HTML
 	 */
-	public function get_landing_page_html( $url, $js_convertkit_object = false ) {
+	public function get_landing_page_html( $url ) {
 
 		$this->log( 'API: get_landing_page_html(): [ url: ' . $url . ']' );
 
@@ -1494,13 +1494,17 @@ class ConvertKit_API {
 			return $body;
 		}
 
+		// Define convertkit JS object.
+		$js_convertkit_object = array(
+			'ajaxurl'       => admin_url( 'admin-ajax.php' ),
+			'nonce'         => wp_create_nonce( 'convertkit' ),
+		);
+
 		// Inject JS for subscriber forms to work.
 		// wp_enqueue_script() isn't called when we load a Landing Page, so we can't use it.
 		// phpcs:disable WordPress.WP.EnqueuedResources
 		$script  = "<script type='text/javascript' src='" . $this->plugin_url . 'resources/frontend/js/convertkit.js?ver=' . $this->plugin_version . "'></script>";
-		if ( $js_convertkit_object ) {
-			$script .= "<script type='text/javascript'>/* <![CDATA[ */var convertkit = " . wp_json_encode( $js_convertkit_object ) . ";/* ]]> */</script>";
-		}
+		$script .= "<script type='text/javascript'>/* <![CDATA[ */var convertkit = " . wp_json_encode( $js_convertkit_object ) . ";/* ]]> */</script>";
 		// phpcs:enable
 
 		$body = str_replace( '</head>', '</head>' . $script, $body );

--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -1479,9 +1479,10 @@ class ConvertKit_API {
 	 * This isn't specifically an API function, but for now it's best suited here.
 	 *
 	 * @param   string $url     URL of Landing Page.
+	 * @param 	bool   $debug   Enable debugging.
 	 * @return  WP_Error|string HTML
 	 */
-	public function get_landing_page_html( $url ) {
+	public function get_landing_page_html( $url, $debug = false ) {
 
 		$this->log( 'API: get_landing_page_html(): [ url: ' . $url . ']' );
 
@@ -1497,6 +1498,7 @@ class ConvertKit_API {
 		// Define convertkit JS object.
 		$js_convertkit_object = array(
 			'ajaxurl' => admin_url( 'admin-ajax.php' ),
+			'debug'	  => $debug,
 			'nonce'   => wp_create_nonce( 'convertkit' ),
 		);
 

--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -1496,15 +1496,15 @@ class ConvertKit_API {
 
 		// Define convertkit JS object.
 		$js_convertkit_object = array(
-			'ajaxurl'       => admin_url( 'admin-ajax.php' ),
-			'nonce'         => wp_create_nonce( 'convertkit' ),
+			'ajaxurl' => admin_url( 'admin-ajax.php' ),
+			'nonce'   => wp_create_nonce( 'convertkit' ),
 		);
 
 		// Inject JS for subscriber forms to work.
 		// wp_enqueue_script() isn't called when we load a Landing Page, so we can't use it.
 		// phpcs:disable WordPress.WP.EnqueuedResources
 		$script  = "<script type='text/javascript' src='" . $this->plugin_url . 'resources/frontend/js/convertkit.js?ver=' . $this->plugin_version . "'></script>";
-		$script .= "<script type='text/javascript'>/* <![CDATA[ */var convertkit = " . wp_json_encode( $js_convertkit_object ) . ";/* ]]> */</script>";
+		$script .= "<script type='text/javascript'>/* <![CDATA[ */var convertkit = " . wp_json_encode( $js_convertkit_object ) . ';/* ]]> */</script>';
 		// phpcs:enable
 
 		$body = str_replace( '</head>', '</head>' . $script, $body );

--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -1479,7 +1479,7 @@ class ConvertKit_API {
 	 * This isn't specifically an API function, but for now it's best suited here.
 	 *
 	 * @param   string $url     URL of Landing Page.
-	 * @param 	bool   $debug   Enable debugging.
+	 * @param   bool   $debug   Enable debugging.
 	 * @return  WP_Error|string HTML
 	 */
 	public function get_landing_page_html( $url, $debug = false ) {
@@ -1498,7 +1498,7 @@ class ConvertKit_API {
 		// Define convertkit JS object.
 		$js_convertkit_object = array(
 			'ajaxurl' => admin_url( 'admin-ajax.php' ),
-			'debug'	  => $debug,
+			'debug'   => $debug,
 			'nonce'   => wp_create_nonce( 'convertkit' ),
 		);
 

--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -1481,7 +1481,7 @@ class ConvertKit_API {
 	 * @param   string $url     URL of Landing Page.
 	 * @return  WP_Error|string HTML
 	 */
-	public function get_landing_page_html( $url ) {
+	public function get_landing_page_html( $url, $js_convertkit_object = false ) {
 
 		$this->log( 'API: get_landing_page_html(): [ url: ' . $url . ']' );
 
@@ -1498,7 +1498,9 @@ class ConvertKit_API {
 		// wp_enqueue_script() isn't called when we load a Landing Page, so we can't use it.
 		// phpcs:disable WordPress.WP.EnqueuedResources
 		$script  = "<script type='text/javascript' src='" . $this->plugin_url . 'resources/frontend/js/convertkit.js?ver=' . $this->plugin_version . "'></script>";
-		$script .= "<script type='text/javascript'>/* <![CDATA[ */var convertkit = {\"ajaxurl\":\"" . admin_url( 'admin-ajax.php' ) . '"};/* ]]> */</script>';
+		if ( $js_convertkit_object ) {
+			$script .= "<script type='text/javascript'>/* <![CDATA[ */var convertkit = " . wp_json_encode( $js_convertkit_object ) . ";/* ]]> */</script>";
+		}
 		// phpcs:enable
 
 		$body = str_replace( '</head>', '</head>' . $script, $body );


### PR DESCRIPTION
## Summary

Fixes a 403 forbidden error on landing pages embedded using the ConvertKit Plugin, due to a missing `nonce` property which the ConvertKit Plugin `convertkit.js` requires to make AJAX requests.

![Screenshot 2024-01-12 at 13 45 31](https://github.com/ConvertKit/convertkit-wordpress-libraries/assets/1462305/4e2a9263-4312-4476-97cb-a704c88dfaf4)

Adds a `debug` method argument, allowing the main Plugin to enable/disable console logging.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)