### PR TITLE
v4 API: Tests: Create Subscriber(s)

### DIFF
--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -462,6 +462,63 @@ class ConvertKit_API {
 	}
 
 	/**
+	 * Get the ConvertKit subscriber ID associated with email address if it exists.
+	 * Return false if subscriber not found.
+	 *
+	 * @param string $email_address Email Address.
+	 *
+	 * @see https://developers.convertkit.com/v4.html#get-a-subscriber
+	 *
+	 * @return WP_Error|false|integer
+	 */
+	public function get_subscriber_id( string $email_address ) {
+
+		$subscribers = $this->get(
+			'subscribers',
+			array( 'email_address' => $email_address )
+		);
+
+		if ( is_wp_error( $subscribers ) ) {
+			return $subscribers;
+		}
+
+		if ( ! count( $subscribers['subscribers'] ) ) {
+			return false;
+		}
+
+		// Return the subscriber's ID.
+		return $subscribers['subscribers'][0]['id'];
+
+	}
+
+	/**
+	 * Unsubscribe an email address.
+	 *
+	 * @param string $email_address Email Address.
+	 *
+	 * @see https://developers.convertkit.com/v4.html#unsubscribe-subscriber
+	 *
+	 * @return WP_Error|false|object
+	 */
+	public function unsubscribe_by_email( string $email_address ) {
+
+		// Get subscriber ID.
+		$subscriber_id = $this->get_subscriber_id( $email_address );
+
+		if ( is_wp_error( $subscriber_id ) ) {
+			return $subscriber_id;
+		}
+
+		return $this->post(
+			sprintf(
+				'subscribers/%s/unsubscribe',
+				(int) $subscriber_id
+			)
+		);
+
+	}
+
+	/**
 	 * Gets all posts from the API.
 	 *
 	 * @since   1.0.0

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -1867,7 +1867,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 			$emailAddress,
 			'', // First name.
 			'', // Subscriber state.
-			fields: [
+			[
 				'not_a_custom_field' => 'value',
 			]
 		);


### PR DESCRIPTION
## Summary

Adds tests for the creation endpoints in the `Subscribers` section of the v4 API, as we have in the PHP SDK.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)