### PR TITLE
v4 API: Tests: Subscribers

### DIFF
--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -469,7 +469,7 @@ class ConvertKit_API {
 	 *
 	 * @see https://developers.convertkit.com/v4.html#get-a-subscriber
 	 *
-	 * @return false|integer
+	 * @return WP_Error|false|integer
 	 */
 	public function get_subscriber_id( string $email_address ) {
 

--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -462,6 +462,36 @@ class ConvertKit_API {
 	}
 
 	/**
+	 * Get the ConvertKit subscriber ID associated with email address if it exists.
+	 * Return false if subscriber not found.
+	 *
+	 * @param string $email_address Email Address.
+	 *
+	 * @see https://developers.convertkit.com/v4.html#get-a-subscriber
+	 *
+	 * @return false|integer
+	 */
+	public function get_subscriber_id( string $email_address ) {
+
+		$subscribers = $this->get(
+			'subscribers',
+			array( 'email_address' => $email_address )
+		);
+
+		if ( is_wp_error( $subscribers ) ) {
+			return $subscribers;
+		}
+
+		if ( ! count( $subscribers['subscribers'] ) ) {
+			return false;
+		}
+
+		// Return the subscriber's ID.
+		return $subscribers['subscribers'][0]['id'];
+
+	}
+
+	/**
 	 * Gets all posts from the API.
 	 *
 	 * @since   1.0.0

--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -492,6 +492,33 @@ class ConvertKit_API {
 	}
 
 	/**
+	 * Unsubscribe an email address.
+	 *
+	 * @param string $email_address Email Address.
+	 *
+	 * @see https://developers.convertkit.com/v4.html#unsubscribe-subscriber
+	 *
+	 * @return WP_Error|false|object
+	 */
+	public function unsubscribe_by_email( string $email_address ) {
+
+		// Get subscriber ID.
+		$subscriber_id = $this->get_subscriber_id( $email_address );
+
+		if ( is_wp_error( $subscriber_id ) ) {
+			return $subscriber_id;
+		}
+
+		return $this->post(
+			sprintf(
+				'subscribers/%s/unsubscribe',
+				(int) $subscriber_id
+			)
+		);
+
+	}
+
+	/**
 	 * Gets all posts from the API.
 	 *
 	 * @since   1.0.0

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -2245,7 +2245,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		);
 
 		// Unsubscribe.
-		$this->assertNull($this->api->unsubscribe($result->subscriber->id));
+		$this->assertNull($this->api->unsubscribe($result['subscriber']['id']));
 	}
 
 	/**

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -2196,6 +2196,8 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$result       = $this->api->create_subscriber(
 			$emailAddress
 		);
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
 
 		// Unsubscribe.
 		$this->assertNull($this->api->unsubscribe_by_email($emailAddress));
@@ -2243,6 +2245,8 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$result       = $this->api->create_subscriber(
 			$emailAddress
 		);
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
 
 		// Unsubscribe.
 		$this->assertNull($this->api->unsubscribe($result['subscriber']['id']));

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -1604,7 +1604,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that get_subscribers() throws a ClientException when an invalid
+	 * Test that get_subscribers() returns a WP_Error when an invalid
 	 * email address is specified.
 	 *
 	 * @since   2.0.0
@@ -1621,7 +1621,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that get_subscribers() throws a ClientException when an invalid
+	 * Test that get_subscribers() returns a WP_Error when an invalid
 	 * subscriber state is specified.
 	 *
 	 * @since   2.0.0
@@ -1637,7 +1637,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that get_subscribers() throws a ClientException when an invalid
+	 * Test that get_subscribers() returns a WP_Error when an invalid
 	 * sort field is specified.
 	 *
 	 * @since   2.0.0
@@ -1659,7 +1659,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that get_subscribers() throws a ClientException when an invalid
+	 * Test that get_subscribers() returns a WP_Error when an invalid
 	 * sort order is specified.
 	 *
 	 * @since   2.0.0
@@ -1682,7 +1682,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that get_subscribers() throws a ClientException when an invalid
+	 * Test that get_subscribers() returns a WP_Error when an invalid
 	 * pagination parameters are specified.
 	 *
 	 * @since   2.0.0
@@ -1816,7 +1816,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that create_subscriber() throws a ClientException when an invalid
+	 * Test that create_subscriber() returns a WP_Error when an invalid
 	 * email address is specified.
 	 *
 	 * @since   2.0.0
@@ -1833,7 +1833,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that create_subscriber() throws a ClientException when an invalid
+	 * Test that create_subscriber() returns a WP_Error when an invalid
 	 * subscriber state is specified.
 	 *
 	 * @since   2.0.0
@@ -1917,7 +1917,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that create_subscribers() throws a ClientException when no data is specified.
+	 * Test that create_subscribers() returns a WP_Error when no data is specified.
 	 *
 	 * @since   2.0.0
 	 *
@@ -1957,6 +1957,430 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		// Assert no subscribers were added.
 		$this->assertCount(0, $result['subscribers']);
 		$this->assertCount(2, $result['failures']);
+	}
+
+	/**
+	 * Test that get_subscriber_id() returns the expected data.
+	 *
+	 * @since   1.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetSubscriberID()
+	{
+		$subscriber_id = $this->api->get_subscriber_id($_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']);
+		$this->assertIsInt($subscriber_id);
+		$this->assertEquals($subscriber_id, (int) $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']);
+	}
+
+	/**
+	 * Test that get_subscriber_id() returns a WP_Error when an invalid
+	 * email address is specified.
+	 *
+	 * @since   1.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetSubscriberIDWithInvalidEmailAddress()
+	{
+		$result = $this->api->get_subscriber_id('not-an-email-address');
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+	}
+
+	/**
+	 * Test that get_subscriber_id() return false when no subscriber found
+	 * matching the given email address.
+	 *
+	 * @since   1.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetSubscriberIDWithNotSubscribedEmailAddress()
+	{
+		$result = $this->api->get_subscriber_id('not-a-subscriber@test.com');
+		$this->assertFalse($result);
+	}
+
+	/**
+	 * Test that get_subscriber() returns the expected data.
+	 *
+	 * @since   1.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetSubscriber()
+	{
+		$result = $this->api->get_subscriber( (int) $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']);
+
+		// Assert subscriber exists with correct data.
+		$this->assertEquals($result['subscriber']['id'], $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']);
+		$this->assertEquals($result['subscriber']['email_address'], $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']);
+	}
+
+	/**
+	 * Test that get_subscriber() returns a WP_Error when an invalid
+	 * subscriber ID is specified.
+	 *
+	 * @since   1.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetSubscriberWithInvalidSubscriberID()
+	{
+		$result = $this->api->get_subscriber(12345);
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+	}
+
+	/**
+	 * Test that update_subscriber() works when no changes are made.
+	 *
+	 * @since   1.0.0
+	 *
+	 * @return void
+	 */
+	public function testUpdateSubscriberWithNoChanges()
+	{
+		$result = $this->api->update_subscriber($_ENV['CONVERTKIT_API_SUBSCRIBER_ID']);
+
+		// Assert subscriber exists with correct data.
+		$this->assertEquals($result['subscriber']['id'], $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']);
+		$this->assertEquals($result['subscriber']['email_address'], $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']);
+	}
+
+	/**
+	 * Test that update_subscriber() works when updating the subscriber's first name.
+	 *
+	 * @since   1.0.0
+	 *
+	 * @return void
+	 */
+	public function testUpdateSubscriberFirstName()
+	{
+		// Add a subscriber.
+		$firstName    = 'FirstName';
+		$emailAddress = $this->generateEmailAddress();
+		$result       = $this->api->create_subscriber(
+			$emailAddress
+		);
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+
+		// Set subscriber_id to ensure subscriber is unsubscribed after test.
+		$this->subscriber_ids[] = $result['subscriber']['id'];
+
+		// Assert subscriber created with no first name.
+		$this->assertNull($result['subscriber']['first_name']);
+
+		// Get subscriber ID.
+		$subscriberID = $result['subscriber']['id'];
+
+		// Update subscriber's first name.
+		$result = $this->api->update_subscriber(
+			$subscriberID,
+			$firstName
+		);
+
+		// Assert changes were made.
+		$this->assertEquals($result['subscriber']['id'], $subscriberID);
+		$this->assertEquals($result['subscriber']['first_name'], $firstName);
+	}
+
+	/**
+	 * Test that update_subscriber() works when updating the subscriber's email address.
+	 *
+	 * @since   1.0.0
+	 *
+	 * @return void
+	 */
+	public function testUpdateSubscriberEmailAddress()
+	{
+		// Add a subscriber.
+		$emailAddress = $this->generateEmailAddress();
+		$result       = $this->api->create_subscriber(
+			$emailAddress
+		);
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+
+		// Set subscriber_id to ensure subscriber is unsubscribed after test.
+		$this->subscriber_ids[] = $result['subscriber']['id'];
+
+		// Assert subscriber created.
+		$this->assertEquals($result['subscriber']['email_address'], $emailAddress);
+
+		// Get subscriber ID.
+		$subscriberID = $result['subscriber']['id'];
+
+		// Update subscriber's email address.
+		$newEmail = $this->generateEmailAddress();
+		$result   = $this->api->update_subscriber(
+			$subscriberID,
+			'', // First name.
+			$newEmail
+		);
+
+		// Assert changes were made.
+		$this->assertEquals($result['subscriber']['id'], $subscriberID);
+		$this->assertEquals($result['subscriber']['email_address'], $newEmail);
+	}
+
+	/**
+	 * Test that update_subscriber() works when updating the subscriber's custom fields.
+	 *
+	 * @since   1.0.0
+	 *
+	 * @return void
+	 */
+	public function testUpdateSubscriberCustomFields()
+	{
+		// Add a subscriber.
+		$lastName     = 'LastName';
+		$emailAddress = $this->generateEmailAddress();
+		$result       = $this->api->create_subscriber(
+			$emailAddress
+		);
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+
+		// Set subscriber_id to ensure subscriber is unsubscribed after test.
+		$this->subscriber_ids[] = $result['subscriber']['id'];
+
+		// Assert subscriber created.
+		$this->assertEquals($result['subscriber']['email_address'], $emailAddress);
+
+		// Get subscriber ID.
+		$subscriberID = $result['subscriber']['id'];
+
+		// Update subscriber's custom fields.
+		$result = $this->api->update_subscriber(
+			$subscriberID,
+			'', // First name.
+			'', // Email address.
+			[
+				'last_name' => $lastName,
+			]
+		);
+
+		// Assert changes were made.
+		$this->assertEquals($result['subscriber']['id'], $subscriberID);
+		$this->assertEquals($result['subscriber']['fields']['last_name'], $lastName);
+	}
+
+	/**
+	 * Test that update_subscriber() returns a WP_Error when an invalid
+	 * subscriber ID is specified.
+	 *
+	 * @since   1.0.0
+	 *
+	 * @return void
+	 */
+	public function testUpdateSubscriberWithInvalidSubscriberID()
+	{
+		$result = $this->api->update_subscriber(12345);
+		$this->assertInstanceOf(WP_Error::class, $result);
+	}
+
+	/**
+	 * Test that unsubscribe_by_email() works with a valid subscriber email address.
+	 *
+	 * @since   1.0.0
+	 *
+	 * @return void
+	 */
+	public function testUnsubscribeByEmail()
+	{
+		// Add a subscriber.
+		$emailAddress = $this->generateEmailAddress();
+		$result       = $this->api->create_subscriber(
+			$emailAddress
+		);
+
+		// Unsubscribe.
+		$this->assertNull($this->api->unsubscribe_by_email($emailAddress));
+	}
+
+	/**
+	 * Test that unsubscribe_by_email() returns a WP_Error when an email
+	 * address is specified that is not subscribed.
+	 *
+	 * @since   1.0.0
+	 *
+	 * @return void
+	 */
+	public function testUnsubscribeByEmailWithNotSubscribedEmailAddress()
+	{
+		$result = $this->api->unsubscribe_by_email('not-subscribed@convertkit.com');
+		$this->assertInstanceOf(WP_Error::class, $result);
+	}
+
+	/**
+	 * Test that unsubscribe_by_email() returns a WP_Error when an invalid
+	 * email address is specified.
+	 *
+	 * @since   1.0.0
+	 *
+	 * @return void
+	 */
+	public function testUnsubscribeByEmailWithInvalidEmailAddress()
+	{
+		$result = $this->api->unsubscribe_by_email('invalid-email');
+		$this->assertInstanceOf(WP_Error::class, $result);
+	}
+
+	/**
+	 * Test that unsubscribe() works with a valid subscriber ID.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testUnsubscribe()
+	{
+		// Add a subscriber.
+		$emailAddress = $this->generateEmailAddress();
+		$result       = $this->api->create_subscriber(
+			$emailAddress
+		);
+
+		// Unsubscribe.
+		$this->assertNull($this->api->unsubscribe($result->subscriber->id));
+	}
+
+	/**
+	 * Test that unsubscribe() returns a WP_Error when an invalid
+	 * subscriber ID is specified.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testUnsubscribeWithInvalidSubscriberID()
+	{
+		$result = $this->api->unsubscribe(12345);
+		$this->assertInstanceOf(WP_Error::class, $result);
+	}
+
+	/**
+	 * Test that get_subscriber_tags() returns the expected data.
+	 *
+	 * @since   1.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetSubscriberTags()
+	{
+		$result = $this->api->get_subscriber_tags( (int) $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']);
+
+		// Assert tags and pagination exist.
+		$this->assertDataExists($result, 'tags');
+		$this->assertPaginationExists($result);
+	}
+
+	/**
+	 * Test that get_subscriber_tags() returns the expected data
+	 * when the total count is included.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetSubscriberTagsWithTotalCount()
+	{
+		$result = $this->api->get_subscriber_tags(
+			(int) $_ENV['CONVERTKIT_API_SUBSCRIBER_ID'],
+			true
+		);
+
+		// Assert tags and pagination exist.
+		$this->assertDataExists($result, 'tags');
+		$this->assertPaginationExists($result);
+
+		// Assert total count is included.
+		$this->assertArrayHasKey('total_count', $result['pagination']);
+		$this->assertGreaterThan(0, $result['pagination']['total_count']);
+	}
+
+	/**
+	 * Test that get_subscriber_tags() returns a WP_Error when an invalid
+	 * subscriber ID is specified.
+	 *
+	 * @since   1.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetSubscriberTagsWithInvalidSubscriberID()
+	{
+		$result = $this->api->get_subscriber_tags(12345);
+		$this->assertInstanceOf(WP_Error::class, $result);
+	}
+
+	/**
+	 * Test that get_subscriber_tags() returns the expected data
+	 * when a valid Subscriber ID is specified and pagination parameters
+	 * and per_page limits are specified.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetSubscriberTagsPagination()
+	{
+		$result = $this->api->get_subscriber_tags(
+			(int) $_ENV['CONVERTKIT_API_SUBSCRIBER_ID'],
+			false, // Include total count.
+			'', // After cursor.
+			'', // Before cursor.
+			1 // Per page.
+		);
+
+		// Assert tags and pagination exist.
+		$this->assertDataExists($result, 'tags');
+		$this->assertPaginationExists($result);
+
+		// Assert a single tag was returned.
+		$this->assertCount(1, $result['tags']);
+
+		// Assert has_previous_page and has_next_page are correct.
+		$this->assertFalse($result['pagination']['has_previous_page']);
+		$this->assertTrue($result['pagination']['has_next_page']);
+
+		// Use pagination to fetch next page.
+		$result = $this->api->get_subscriber_tags(
+			(int) $_ENV['CONVERTKIT_API_SUBSCRIBER_ID'],
+			false, // Include total count.
+			$result['pagination']['end_cursor'], // After cursor.
+			'', // Before cursor.
+			1 // Per page.
+		);
+
+		// Assert tags and pagination exist.
+		$this->assertDataExists($result, 'tags');
+		$this->assertPaginationExists($result);
+
+		// Assert a single tag was returned.
+		$this->assertCount(1, $result['tags']);
+
+		// Assert has_previous_page and has_next_page are correct.
+		$this->assertTrue($result['pagination']['has_previous_page']);
+		$this->assertTrue($result['pagination']['has_next_page']);
+
+		// Use pagination to fetch previous page.
+		$result = $this->api->get_subscriber_tags(
+			(int) $_ENV['CONVERTKIT_API_SUBSCRIBER_ID'],
+			false, // Include total count.
+			'', // After cursor.
+			$result['pagination']['start_cursor'], // Before cursor.
+			1 // Per page.
+		);
+
+		// Assert tags and pagination exist.
+		$this->assertDataExists($result, 'tags');
+		$this->assertPaginationExists($result);
+
+		// Assert a single tag was returned.
+		$this->assertCount(1, $result['tags']);
 	}
 
 	/**
@@ -2136,7 +2560,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that get_broadcast() throws a ClientException when an invalid
+	 * Test that get_broadcast() returns a WP_Error when an invalid
 	 * broadcast ID is specified.
 	 *
 	 * @since   2.0.0
@@ -2173,7 +2597,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that get_broadcast_stats() throws a ClientException when an invalid
+	 * Test that get_broadcast_stats() returns a WP_Error when an invalid
 	 * broadcast ID is specified.
 	 *
 	 * @since   2.0.0
@@ -2187,7 +2611,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that update_broadcast() throws a ClientException when an invalid
+	 * Test that update_broadcast() returns a WP_Error when an invalid
 	 * broadcast ID is specified.
 	 *
 	 * @since   1.0.0
@@ -2201,7 +2625,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that delete_broadcast() throws a ClientException when an invalid
+	 * Test that delete_broadcast() returns a WP_Error when an invalid
 	 * broadcast ID is specified.
 	 *
 	 * @since   1.0.0


### PR DESCRIPTION
## Summary

Adds tests for the remaining endpoints in the `Subscribers` section of the v4 API, as we have in the PHP SDK.

Overrides the trait's `get_subscriber_id` and `unsubscribe_by_email` methods to return a `WP_Error` if the email address supplied is invalid.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)