### PR TITLE
v4 API: Tests: Email Templates

### DIFF
--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -1500,6 +1500,95 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$this->assertEquals('Not Found: The entity you were trying to find doesn\'t exist', $result->get_error_message());
 	}
 
+	/**
+	 * Test that get_email_templates() returns the expected data.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetEmailTemplates()
+	{
+		$result = $this->api->get_email_templates();
+
+		// Assert email templates and pagination exist.
+		$this->assertDataExists($result, 'email_templates');
+		$this->assertPaginationExists($result);
+	}
+
+	/**
+	 * Test that get_email_templates() returns the expected data
+	 * when the total count is included.
+	 *
+	 * @since   1.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetEmailTemplatesWithTotalCount()
+	{
+		$result = $this->api->get_email_templates(true);
+
+		// Assert email templates and pagination exist.
+		$this->assertDataExists($result, 'email_templates');
+		$this->assertPaginationExists($result);
+
+		// Assert total count is included.
+		$this->assertArrayHasKey('total_count', $result['pagination']);
+		$this->assertGreaterThan(0, $result['pagination']['total_count']);
+	}
+
+	/**
+	 * Test that get_email_templates() returns the expected data
+	 * when pagination parameters and per_page limits are specified.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetEmailTemplatesPagination()
+	{
+		// Return one broadcast.
+		$result = $this->api->get_email_templates(false, '', '', 1);
+
+		// Assert email templates and pagination exist.
+		$this->assertDataExists($result, 'email_templates');
+		$this->assertPaginationExists($result);
+
+		// Assert a single email template was returned.
+		$this->assertCount(1, $result['email_templates']);
+
+		// Assert has_previous_page and has_next_page are correct.
+		$this->assertFalse($result['pagination']['has_previous_page']);
+		$this->assertTrue($result['pagination']['has_next_page']);
+
+		// Use pagination to fetch next page.
+		$result = $this->api->get_email_templates(false, $result['pagination']['end_cursor'], '', 1);
+
+		// Assert email templates and pagination exist.
+		$this->assertDataExists($result, 'email_templates');
+		$this->assertPaginationExists($result);
+
+		// Assert a single email template was returned.
+		$this->assertCount(1, $result['email_templates']);
+
+		// Assert has_previous_page and has_next_page are correct.
+		$this->assertTrue($result['pagination']['has_previous_page']);
+		$this->assertTrue($result['pagination']['has_next_page']);
+
+		// Use pagination to fetch previous page.
+		$result = $this->api->get_email_templates(false, '', $result['pagination']['start_cursor'], 1);
+
+		// Assert email templates and pagination exist.
+		$this->assertDataExists($result, 'email_templates');
+		$this->assertPaginationExists($result);
+
+		// Assert a single email template was returned.
+		$this->assertCount(1, $result['email_templates']);
+
+		// Assert has_previous_page and has_next_page are correct.
+		$this->assertFalse($result['pagination']['has_previous_page']);
+		$this->assertTrue($result['pagination']['has_next_page']);
+	}
 
 	/**
 	 * Test that get_broadcasts() returns the expected data

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -2397,7 +2397,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$this->assertCount(1, $result['tags']);
 	}
 
-/**
+	/**
 	 * Test that get_email_templates() returns the expected data.
 	 *
 	 * @since   2.0.0


### PR DESCRIPTION
## Summary

Adds tests for endpoints in the `Email Templates` section of the v4 API, as we have in the PHP SDK.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)