### PR TITLE
v4 API: Tests: Webhooks

### DIFF
--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -59,6 +59,15 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	protected $broadcast_ids = [];
 
 	/**
+	 * Webhook IDs to delete on teardown of a test.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @var     array<int, int>
+	 */
+	protected $webhook_ids = [];
+
+	/**
 	 * Performs actions before each test.
 	 *
 	 * @since   1.0.0
@@ -103,6 +112,11 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		// Unsubscribe any Subscribers.
 		foreach ($this->subscriber_ids as $id) {
 			$this->api->unsubscribe($id);
+		}
+
+		// Delete any Webhooks.
+		foreach ($this->webhook_ids as $id) {
+			$this->api->delete_webhook($id);
 		}
 
 		// Delete any Broadcasts.

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -2796,8 +2796,8 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->api->create_webhook(
-			url: 'https://webhook.site/' . str_shuffle('wfervdrtgsdewrafvwefds'),
-			event: 'invalid.event'
+			'https://webhook.site/' . str_shuffle('wfervdrtgsdewrafvwefds'),
+			'invalid.event'
 		);
 	}
 


### PR DESCRIPTION
## Summary

Adds tests for endpoints in the `Webhooks` section of the v4 API, as we have in the PHP SDK.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)