### PR TITLE
v4 API: Tests: Sequences

### DIFF
--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -1196,20 +1196,8 @@ class ConvertKit_API {
 
 		// Return the API error message as a WP_Error if the HTTP response code is a 4xx code.
 		if ( $http_response_code >= 400 ) {
-			// Define the error description.
-			$error = '';
-			if ( array_key_exists( 'errors', $response ) ) {
-				$error = implode( "\n", $response['errors'] );
-			} elseif ( array_key_exists( 'error_description', $response ) ) {
-				$error = $response['error_description'];
-			} elseif ( array_key_exists( 'error', $response ) ) {
-				// The 'error' key is present when exchanging an API Key and Secret for an Access Token
-				// and something went wrong e.g. invalid API credentials.
-				$error = $response['error'];
-				if ( array_key_exists( 'message', $response ) ) {
-					$error .= ': ' . $response['message'];
-				}
-			}
+			// Define the error message.
+			$error = $this->get_error_message_string( $response );
 
 			$this->log( 'API: Error: ' . $error );
 
@@ -1256,6 +1244,58 @@ class ConvertKit_API {
 		}
 
 		return $response;
+
+	}
+
+	/**
+	 * Inspects the given API response for errors, returning them as a string.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @param   array $response   API Response.
+	 * @return  string              Error Message(s).
+	 */
+	private function get_error_message_string( $response ) {
+
+		// Most API responses contain the `errors` key.
+		if ( array_key_exists( 'errors', $response ) ) {
+			$error_message = '';
+
+			// For sequences, each item in the `errors` key is an array.
+			// For other API endpoints, each item in the `errors` key is a string.
+			foreach ( $response['errors'] as $error ) {
+				if ( is_array( $error ) ) {
+					$error_message .= implode( "\n", $error );
+					continue;
+				}
+
+				// Error is a string.
+				$error_message .= "\n" . $error;
+			}
+
+			return $error_message;
+		}
+
+		// Some might provide an `error_description`.
+		if ( array_key_exists( 'error_description', $response ) ) {
+			return $response['error_description'];
+		}
+
+		// The `error` key is present when exchanging an API Key and Secret for an Access Token
+		// and something went wrong e.g. invalid API credentials.
+		if ( array_key_exists( 'error', $response ) ) {
+			$error_message = $response['error'];
+
+			// There might be additional information we can return.
+			if ( array_key_exists( 'message', $response ) ) {
+				$error_message .= ': ' . $response['message'];
+			}
+
+			return $error_message;
+		}
+
+		// If here, no error was detected.
+		return '';
 
 	}
 

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -977,12 +977,12 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	{
 		// Create subscriber.
 		$emailAddress = $this->generateEmailAddress();
-		$subscriber   = $this->api->create_subscriber($emailAddress);
+		$result       = $this->api->create_subscriber($emailAddress);
 		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertIsArray($result);
 
 		// Set subscriber_id to ensure subscriber is unsubscribed after test.
-		$this->subscriber_ids[] = $subscriber['subscriber']['id'];
+		$this->subscriber_ids[] = $result['subscriber']['id'];
 
 		// Add subscriber to sequence.
 		$result = $this->api->add_subscriber_to_sequence_by_email(
@@ -1049,8 +1049,8 @@ class APITest extends \Codeception\TestCase\WPTestCase
 			$this->generateEmailAddress()
 		);
 
-		$this->assertNotInstanceOf(WP_Error::class, $result);
-		$this->assertIsArray($result);
+		$this->assertNotInstanceOf(WP_Error::class, $subscriber);
+		$this->assertIsArray($subscriber);
 
 		// Set subscriber_id to ensure subscriber is unsubscribed after test.
 		$this->subscriber_ids[] = $subscriber['subscriber']['id'];

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -845,60 +845,60 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-     * Test that get_sequences() returns the expected data.
-     *
-     * @since   1.0.0
-     *
-     * @return void
-     */
-    public function testGetSequences()
-    {
-        $result = $this->api->get_sequences();
+	 * Test that get_sequences() returns the expected data.
+	 *
+	 * @since   1.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetSequences()
+	{
+		$result = $this->api->get_sequences();
 
-        // Assert sequences and pagination exist.
-        $this->assertDataExists($result, 'sequences');
-        $this->assertPaginationExists($result);
+		// Assert sequences and pagination exist.
+		$this->assertDataExists($result, 'sequences');
+		$this->assertPaginationExists($result);
 
-        // Check first sequence in resultset has expected data.
-        $sequence = $result['sequences'][0];
-        $this->assertArrayHasKey('id', $sequence);
-        $this->assertArrayHasKey('name', $sequence);
-        $this->assertArrayHasKey('hold', $sequence);
-        $this->assertArrayHasKey('repeat', $sequence);
-        $this->assertArrayHasKey('created_at', $sequence);
-    }
+		// Check first sequence in resultset has expected data.
+		$sequence = $result['sequences'][0];
+		$this->assertArrayHasKey('id', $sequence);
+		$this->assertArrayHasKey('name', $sequence);
+		$this->assertArrayHasKey('hold', $sequence);
+		$this->assertArrayHasKey('repeat', $sequence);
+		$this->assertArrayHasKey('created_at', $sequence);
+	}
 
-    /**
-     * Test that get_sequences() returns the expected data
-     * when the total count is included.
-     *
-     * @since   2.0.0
-     *
-     * @return void
-     */
-    public function testGetSequencesWithTotalCount()
-    {
-        $result = $this->api->get_sequences(true);
+	/**
+	 * Test that get_sequences() returns the expected data
+	 * when the total count is included.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetSequencesWithTotalCount()
+	{
+		$result = $this->api->get_sequences(true);
 
-        // Assert sequences and pagination exist.
-        $this->assertDataExists($result, 'sequences');
-        $this->assertPaginationExists($result);
+		// Assert sequences and pagination exist.
+		$this->assertDataExists($result, 'sequences');
+		$this->assertPaginationExists($result);
 
-        // Assert total count is included.
-        $this->assertArrayHasKey('total_count', $result['pagination']);
-        $this->assertGreaterThan(0, $result['pagination']['total_count']);
-    }
+		// Assert total count is included.
+		$this->assertArrayHasKey('total_count', $result['pagination']);
+		$this->assertGreaterThan(0, $result['pagination']['total_count']);
+	}
 
-    /**
-     * Test that get_sequences() returns the expected data when
-     * pagination parameters and per_page limits are specified.
-     *
-     * @since   2.0.0
-     *
-     * @return void
-     */
-    public function testGetSequencesPagination()
-    {
+	/**
+	 * Test that get_sequences() returns the expected data when
+	 * pagination parameters and per_page limits are specified.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetSequencesPagination()
+	{
 		// Return one sequence.
 		$result = $this->api->get_sequences(false, '', '', 1);
 
@@ -940,465 +940,465 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		// Assert has_previous_page and has_next_page are correct.
 		$this->assertFalse($result['pagination']['has_previous_page']);
 		$this->assertTrue($result['pagination']['has_next_page']);
-    }
+	}
 
-    /**
-     * Test that add_subscriber_to_sequence_by_email() returns the expected data.
-     *
-     * @since   1.0.0
-     *
-     * @return void
-     */
-    public function testAddSubscriberToSequenceByEmail()
-    {
-        // Create subscriber.
-        $emailAddress = $this->generateEmailAddress();
-        $subscriber = $this->api->create_subscriber($emailAddress);
-        $this->assertNotInstanceOf(WP_Error::class, $result);
+	/**
+	 * Test that add_subscriber_to_sequence_by_email() returns the expected data.
+	 *
+	 * @since   1.0.0
+	 *
+	 * @return void
+	 */
+	public function testAddSubscriberToSequenceByEmail()
+	{
+		// Create subscriber.
+		$emailAddress = $this->generateEmailAddress();
+		$subscriber   = $this->api->create_subscriber($emailAddress);
+		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertIsArray($result);
 
-        // Set subscriber_id to ensure subscriber is unsubscribed after test.
-        $this->subscriber_ids[] = $subscriber['subscriber']['id'];
+		// Set subscriber_id to ensure subscriber is unsubscribed after test.
+		$this->subscriber_ids[] = $subscriber['subscriber']['id'];
 
-        // Add subscriber to sequence.
-        $result = $this->api->add_subscriber_to_sequence_by_email(
-            $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
-            $emailAddress
-        );
-        $this->assertNotInstanceOf(WP_Error::class, $result);
+		// Add subscriber to sequence.
+		$result = $this->api->add_subscriber_to_sequence_by_email(
+			$_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+			$emailAddress
+		);
+		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertIsArray($result);
-        $this->assertArrayHasKey('subscriber', $result);
-        $this->assertArrayHasKey('id', $result['subscriber']);
-        $this->assertEquals(
-            $result['subscriber']['email_address'],
-            $emailAddress
-        );
-    }
+		$this->assertArrayHasKey('subscriber', $result);
+		$this->assertArrayHasKey('id', $result['subscriber']);
+		$this->assertEquals(
+			$result['subscriber']['email_address'],
+			$emailAddress
+		);
+	}
 
-    /**
-     * Test that add_subscriber_to_sequence_by_email() returns a WP_Error when an invalid
-     * sequence is specified.
-     *
-     * @since   1.0.0
-     *
-     * @return void
-     */
-    public function testAddSubscriberToSequenceByEmailWithInvalidSequenceID()
-    {
-        $result = $this->api->add_subscriber_to_sequence_by_email(
-            12345,
-            $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']
-        );
-        $this->assertInstanceOf(WP_Error::class, $result);
+	/**
+	 * Test that add_subscriber_to_sequence_by_email() returns a WP_Error when an invalid
+	 * sequence is specified.
+	 *
+	 * @since   1.0.0
+	 *
+	 * @return void
+	 */
+	public function testAddSubscriberToSequenceByEmailWithInvalidSequenceID()
+	{
+		$result = $this->api->add_subscriber_to_sequence_by_email(
+			12345,
+			$_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']
+		);
+		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
-    }
+	}
 
-    /**
-     * Test that add_subscriber_to_sequence_by_email() returns a WP_Error when an invalid
-     * email address is specified.
-     *
-     * @since   1.0.0
-     *
-     * @return void
-     */
-    public function testAddSubscriberToSequenceByEmailWithInvalidEmailAddress()
-    {
-        $result = $this->api->add_subscriber_to_sequence_by_email(
-            $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
-            'not-an-email-address'
-        );
-        $this->assertInstanceOf(WP_Error::class, $result);
+	/**
+	 * Test that add_subscriber_to_sequence_by_email() returns a WP_Error when an invalid
+	 * email address is specified.
+	 *
+	 * @since   1.0.0
+	 *
+	 * @return void
+	 */
+	public function testAddSubscriberToSequenceByEmailWithInvalidEmailAddress()
+	{
+		$result = $this->api->add_subscriber_to_sequence_by_email(
+			$_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+			'not-an-email-address'
+		);
+		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
-    }
+	}
 
-    /**
-     * Test that add_subscriber_to_sequence() returns the expected data.
-     *
-     * @since   2.0.0
-     *
-     * @return void
-     */
-    public function testAddSubscriberToSequence()
-    {
-        // Create subscriber.
-        $subscriber = $this->api->create_subscriber(
-            $this->generateEmailAddress()
-        );
+	/**
+	 * Test that add_subscriber_to_sequence() returns the expected data.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testAddSubscriberToSequence()
+	{
+		// Create subscriber.
+		$subscriber = $this->api->create_subscriber(
+			$this->generateEmailAddress()
+		);
 
-        $this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertIsArray($result);
 
-        // Set subscriber_id to ensure subscriber is unsubscribed after test.
-        $this->subscriber_ids[] = $subscriber['subscriber']['id'];
+		// Set subscriber_id to ensure subscriber is unsubscribed after test.
+		$this->subscriber_ids[] = $subscriber['subscriber']['id'];
 
-        // Add subscriber to sequence.
-        $result = $this->api->add_subscriber_to_sequence(
-            (int) $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
-            $subscriber['subscriber']['id']
-        );
-        $this->assertNotInstanceOf(WP_Error::class, $result);
+		// Add subscriber to sequence.
+		$result = $this->api->add_subscriber_to_sequence(
+			(int) $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+			$subscriber['subscriber']['id']
+		);
+		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertIsArray($result);
-        $this->assertArrayHasKey('subscriber', $result);
-        $this->assertArrayHasKey('id', $result['subscriber']);
-        $this->assertEquals($result['subscriber']['id'], $subscriber['subscriber']['id']);
-    }
+		$this->assertArrayHasKey('subscriber', $result);
+		$this->assertArrayHasKey('id', $result['subscriber']);
+		$this->assertEquals($result['subscriber']['id'], $subscriber['subscriber']['id']);
+	}
 
-    /**
-     * Test that add_subscriber_to_sequence() returns a WP_Error when an invalid
-     * sequence ID is specified.
-     *
-     * @since   2.0.0
-     *
-     * @return void
-     */
-    public function testAddSubscriberToSequenceWithInvalidSequenceID()
-    {
-        $result = $this->api->add_subscriber_to_sequence(
-            12345,
-            $_ENV['CONVERTKIT_API_SUBSCRIBER_ID']
-        );
-        $this->assertInstanceOf(WP_Error::class, $result);
+	/**
+	 * Test that add_subscriber_to_sequence() returns a WP_Error when an invalid
+	 * sequence ID is specified.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testAddSubscriberToSequenceWithInvalidSequenceID()
+	{
+		$result = $this->api->add_subscriber_to_sequence(
+			12345,
+			$_ENV['CONVERTKIT_API_SUBSCRIBER_ID']
+		);
+		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
-    }
+	}
 
-    /**
-     * Test that add_subscriber_to_sequence() returns a WP_Error when an invalid
-     * email address is specified.
-     *
-     * @since   2.0.0
-     *
-     * @return void
-     */
-    public function testAddSubscriberToSequenceWithInvalidSubscriberID()
-    {
-        $result = $this->api->add_subscriber_to_sequence(
-            $_ENV['CONVERTKIT_API_SUBSCRIBER_ID'],
-            12345
-        );
-        $this->assertInstanceOf(WP_Error::class, $result);
+	/**
+	 * Test that add_subscriber_to_sequence() returns a WP_Error when an invalid
+	 * email address is specified.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testAddSubscriberToSequenceWithInvalidSubscriberID()
+	{
+		$result = $this->api->add_subscriber_to_sequence(
+			$_ENV['CONVERTKIT_API_SUBSCRIBER_ID'],
+			12345
+		);
+		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
-    }
+	}
 
-    /**
-     * Test that get_sequence_subscriptions() returns the expected data.
-     *
-     * @since   1.0.0
-     *
-     * @return void
-     */
-    public function testGetSequenceSubscriptions()
-    {
-        $result = $this->api->get_sequence_subscriptions($_ENV['CONVERTKIT_API_SEQUENCE_ID']);
+	/**
+	 * Test that get_sequence_subscriptions() returns the expected data.
+	 *
+	 * @since   1.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetSequenceSubscriptions()
+	{
+		$result = $this->api->get_sequence_subscriptions($_ENV['CONVERTKIT_API_SEQUENCE_ID']);
 
-        // Assert subscribers and pagination exist.
-        $this->assertDataExists($result, 'subscribers');
-        $this->assertPaginationExists($result);
-    }
+		// Assert subscribers and pagination exist.
+		$this->assertDataExists($result, 'subscribers');
+		$this->assertPaginationExists($result);
+	}
 
-    /**
-     * Test that get_sequence_subscriptions() returns the expected data
-     * when the total count is included.
-     *
-     * @since   2.0.0
-     *
-     * @return void
-     */
-    public function testGetSequenceSubscriptionsWithTotalCount()
-    {
-        $result = $this->api->get_sequence_subscriptions(
-            $_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Sequence ID.
-            'active', // Subscriber state.
-            null, // Created after.
-            null, // Created before.
-            null, // Added after.
-            null, // Added before.
-            true // Include total count.
-        );
+	/**
+	 * Test that get_sequence_subscriptions() returns the expected data
+	 * when the total count is included.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetSequenceSubscriptionsWithTotalCount()
+	{
+		$result = $this->api->get_sequence_subscriptions(
+			$_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Sequence ID.
+			'active', // Subscriber state.
+			null, // Created after.
+			null, // Created before.
+			null, // Added after.
+			null, // Added before.
+			true // Include total count.
+		);
 
-        // Assert subscribers and pagination exist.
-        $this->assertDataExists($result, 'subscribers');
-        $this->assertPaginationExists($result);
+		// Assert subscribers and pagination exist.
+		$this->assertDataExists($result, 'subscribers');
+		$this->assertPaginationExists($result);
 
-        // Assert total count is included.
-        $this->assertArrayHasKey('total_count', $result['pagination']);
-        $this->assertGreaterThan(0, $result['pagination']['total_count']);
-    }
+		// Assert total count is included.
+		$this->assertArrayHasKey('total_count', $result['pagination']);
+		$this->assertGreaterThan(0, $result['pagination']['total_count']);
+	}
 
-    /**
-     * Test that get_sequence_subscriptions() returns the expected data
-     * when a valid Sequence ID is specified and the subscription status
-     * is cancelled.
-     *
-     * @since   1.0.0
-     *
-     * @return void
-     */
-    public function testGetSequenceSubscriptionsWithBouncedSubscriberState()
-    {
-        $result = $this->api->get_sequence_subscriptions(
-            $_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Sequence ID.
-            'bounced' // Subscriber state.
-        );
+	/**
+	 * Test that get_sequence_subscriptions() returns the expected data
+	 * when a valid Sequence ID is specified and the subscription status
+	 * is cancelled.
+	 *
+	 * @since   1.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetSequenceSubscriptionsWithBouncedSubscriberState()
+	{
+		$result = $this->api->get_sequence_subscriptions(
+			$_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Sequence ID.
+			'bounced' // Subscriber state.
+		);
 
-        // Assert subscribers and pagination exist.
-        $this->assertDataExists($result, 'subscribers');
-        $this->assertPaginationExists($result);
+		// Assert subscribers and pagination exist.
+		$this->assertDataExists($result, 'subscribers');
+		$this->assertPaginationExists($result);
 
-        // Check the correct subscribers were returned.
-        $this->assertEquals($result['subscribers'][0]['state'], 'bounced');
-    }
+		// Check the correct subscribers were returned.
+		$this->assertEquals($result['subscribers'][0]['state'], 'bounced');
+	}
 
-    /**
-     * Test that get_sequence_subscriptions() returns the expected data
-     * when a valid Sequence ID is specified and the added_after parameter
-     * is used.
-     *
-     * @since   2.0.0
-     *
-     * @return void
-     */
-    public function testGetSequenceSubscriptionsWithAddedAfterParam()
-    {
-        $date = new \DateTime('2024-01-01');
-        $result = $this->api->get_sequence_subscriptions(
-        	$_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Sequence ID.
-            'active', // Subscriber state.
-            null, // Created after.
-            null, // Created before.
-            $date // Added after.
-        );
+	/**
+	 * Test that get_sequence_subscriptions() returns the expected data
+	 * when a valid Sequence ID is specified and the added_after parameter
+	 * is used.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetSequenceSubscriptionsWithAddedAfterParam()
+	{
+		$date   = new \DateTime('2024-01-01');
+		$result = $this->api->get_sequence_subscriptions(
+			$_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Sequence ID.
+			'active', // Subscriber state.
+			null, // Created after.
+			null, // Created before.
+			$date // Added after.
+		);
 
-        // Assert subscribers and pagination exist.
-        $this->assertDataExists($result, 'subscribers');
-        $this->assertPaginationExists($result);
+		// Assert subscribers and pagination exist.
+		$this->assertDataExists($result, 'subscribers');
+		$this->assertPaginationExists($result);
 
-        // Check the correct subscribers were returned.
-        $this->assertGreaterThanOrEqual(
-            $date->format('Y-m-d'),
-            date('Y-m-d', strtotime($result['subscribers'][0]['added_at']))
-        );
-    }
+		// Check the correct subscribers were returned.
+		$this->assertGreaterThanOrEqual(
+			$date->format('Y-m-d'),
+			date('Y-m-d', strtotime($result['subscribers'][0]['added_at']))
+		);
+	}
 
-    /**
-     * Test that get_sequence_subscriptions() returns the expected data
-     * when a valid Sequence ID is specified and the added_before parameter
-     * is used.
-     *
-     * @since   2.0.0
-     *
-     * @return void
-     */
-    public function testGetSequenceSubscriptionsWithAddedBeforeParam()
-    {
-        $date = new \DateTime('2024-01-01');
-        $result = $this->api->get_sequence_subscriptions(
-            $_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Sequence ID.
-            'active', // Subscriber state.
-            null, // Created after.
-            null, // Created before.
-            null, // Added after.
-            $date // Added before.
-        );
+	/**
+	 * Test that get_sequence_subscriptions() returns the expected data
+	 * when a valid Sequence ID is specified and the added_before parameter
+	 * is used.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetSequenceSubscriptionsWithAddedBeforeParam()
+	{
+		$date   = new \DateTime('2024-01-01');
+		$result = $this->api->get_sequence_subscriptions(
+			$_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Sequence ID.
+			'active', // Subscriber state.
+			null, // Created after.
+			null, // Created before.
+			null, // Added after.
+			$date // Added before.
+		);
 
-        // Assert subscribers and pagination exist.
-        $this->assertDataExists($result, 'subscribers');
-        $this->assertPaginationExists($result);
+		// Assert subscribers and pagination exist.
+		$this->assertDataExists($result, 'subscribers');
+		$this->assertPaginationExists($result);
 
-        // Check the correct subscribers were returned.
-        $this->assertLessThanOrEqual(
-            $date->format('Y-m-d'),
-            date('Y-m-d', strtotime($result['subscribers'][0]['added_at']))
-        );
-    }
+		// Check the correct subscribers were returned.
+		$this->assertLessThanOrEqual(
+			$date->format('Y-m-d'),
+			date('Y-m-d', strtotime($result['subscribers'][0]['added_at']))
+		);
+	}
 
-    /**
-     * Test that get_sequence_subscriptions() returns the expected data
-     * when a valid Sequence ID is specified and the created_after parameter
-     * is used.
-     *
-     * @since   2.0.0
-     *
-     * @return void
-     */
-    public function testGetSequenceSubscriptionsWithCreatedAfterParam()
-    {
-        $date = new \DateTime('2024-01-01');
-        $result = $this->api->get_sequence_subscriptions(
-        	$_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Sequence ID.
-            'active', // Subscriber state.
-            $date // Created after.
-        );
+	/**
+	 * Test that get_sequence_subscriptions() returns the expected data
+	 * when a valid Sequence ID is specified and the created_after parameter
+	 * is used.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetSequenceSubscriptionsWithCreatedAfterParam()
+	{
+		$date   = new \DateTime('2024-01-01');
+		$result = $this->api->get_sequence_subscriptions(
+			$_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Sequence ID.
+			'active', // Subscriber state.
+			$date // Created after.
+		);
 
-        // Assert subscribers and pagination exist.
-        $this->assertDataExists($result, 'subscribers');
-        $this->assertPaginationExists($result);
+		// Assert subscribers and pagination exist.
+		$this->assertDataExists($result, 'subscribers');
+		$this->assertPaginationExists($result);
 
-        // Check the correct subscribers were returned.
-        $this->assertGreaterThanOrEqual(
-            $date->format('Y-m-d'),
-            date('Y-m-d', strtotime($result['subscribers'][0]['created_at']))
-        );
-    }
+		// Check the correct subscribers were returned.
+		$this->assertGreaterThanOrEqual(
+			$date->format('Y-m-d'),
+			date('Y-m-d', strtotime($result['subscribers'][0]['created_at']))
+		);
+	}
 
-    /**
-     * Test that get_sequence_subscriptions() returns the expected data
-     * when a valid Sequence ID is specified and the created_before parameter
-     * is used.
-     *
-     * @since   2.0.0
-     *
-     * @return void
-     */
-    public function testGetSequenceSubscriptionsWithCreatedBeforeParam()
-    {
-        $date = new \DateTime('2024-01-01');
-        $result = $this->api->get_sequence_subscriptions(
-            $_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Sequence ID.
-            'active', // Subscriber state.
-            null, // Created after.
-            $date // Created before.
-        );
+	/**
+	 * Test that get_sequence_subscriptions() returns the expected data
+	 * when a valid Sequence ID is specified and the created_before parameter
+	 * is used.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetSequenceSubscriptionsWithCreatedBeforeParam()
+	{
+		$date   = new \DateTime('2024-01-01');
+		$result = $this->api->get_sequence_subscriptions(
+			$_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Sequence ID.
+			'active', // Subscriber state.
+			null, // Created after.
+			$date // Created before.
+		);
 
-        // Assert subscribers and pagination exist.
-        $this->assertDataExists($result, 'subscribers');
-        $this->assertPaginationExists($result);
+		// Assert subscribers and pagination exist.
+		$this->assertDataExists($result, 'subscribers');
+		$this->assertPaginationExists($result);
 
-        // Check the correct subscribers were returned.
-        $this->assertLessThanOrEqual(
-            $date->format('Y-m-d'),
-            date('Y-m-d', strtotime($result['subscribers'][0]['created_at']))
-        );
-    }
+		// Check the correct subscribers were returned.
+		$this->assertLessThanOrEqual(
+			$date->format('Y-m-d'),
+			date('Y-m-d', strtotime($result['subscribers'][0]['created_at']))
+		);
+	}
 
-    /**
-     * Test that get_sequence_subscriptions() returns the expected data
-     * when a valid Sequence ID is specified and pagination parameters
-     * and per_page limits are specified.
-     *
-     * @since   1.0.0
-     *
-     * @return void
-     */
-    public function testGetSequenceSubscriptionsPagination()
-    {
-        $result = $this->api->get_sequence_subscriptions(
-            $_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Sequence ID.
-            'active', // Subscriber state.
-            null, // Created after.
-            null, // Created before.
-            null, // Added after.
-            null, // Added before.
-            false, // Include total count.
-            '', // After cursor.
-            '', // Before cursor.
-            1 // Per page.
-        );
+	/**
+	 * Test that get_sequence_subscriptions() returns the expected data
+	 * when a valid Sequence ID is specified and pagination parameters
+	 * and per_page limits are specified.
+	 *
+	 * @since   1.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetSequenceSubscriptionsPagination()
+	{
+		$result = $this->api->get_sequence_subscriptions(
+			$_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Sequence ID.
+			'active', // Subscriber state.
+			null, // Created after.
+			null, // Created before.
+			null, // Added after.
+			null, // Added before.
+			false, // Include total count.
+			'', // After cursor.
+			'', // Before cursor.
+			1 // Per page.
+		);
 
-        // Assert subscribers and pagination exist.
-        $this->assertDataExists($result, 'subscribers');
-        $this->assertPaginationExists($result);
+		// Assert subscribers and pagination exist.
+		$this->assertDataExists($result, 'subscribers');
+		$this->assertPaginationExists($result);
 
-        // Assert a single subscriber was returned.
-        $this->assertCount(1, $result['subscribers']);
+		// Assert a single subscriber was returned.
+		$this->assertCount(1, $result['subscribers']);
 
-        // Assert has_previous_page and has_next_page are correct.
-        $this->assertFalse($result['pagination']['has_previous_page']);
-        $this->assertTrue($result['pagination']['has_next_page']);
+		// Assert has_previous_page and has_next_page are correct.
+		$this->assertFalse($result['pagination']['has_previous_page']);
+		$this->assertTrue($result['pagination']['has_next_page']);
 
-        // Use pagination to fetch next page.
-        $result = $this->api->get_sequence_subscriptions(
-            $_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Sequence ID.
-            'active', // Subscriber state.
-            null, // Created after.
-            null, // Created before.
-            null, // Added after.
-            null, // Added before.
-            false, // Include total count.
-            $result['pagination']['end_cursor'], // After cursor.
-            '', // Before cursor.
-            1 // Per page.
-        );  
+		// Use pagination to fetch next page.
+		$result = $this->api->get_sequence_subscriptions(
+			$_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Sequence ID.
+			'active', // Subscriber state.
+			null, // Created after.
+			null, // Created before.
+			null, // Added after.
+			null, // Added before.
+			false, // Include total count.
+			$result['pagination']['end_cursor'], // After cursor.
+			'', // Before cursor.
+			1 // Per page.
+		);
 
-        // Assert subscribers and pagination exist.
-        $this->assertDataExists($result, 'subscribers');
-        $this->assertPaginationExists($result);
+		// Assert subscribers and pagination exist.
+		$this->assertDataExists($result, 'subscribers');
+		$this->assertPaginationExists($result);
 
-        // Assert a single subscriber was returned.
-        $this->assertCount(1, $result['subscribers']);
+		// Assert a single subscriber was returned.
+		$this->assertCount(1, $result['subscribers']);
 
-        // Assert has_previous_page and has_next_page are correct.
-        $this->assertTrue($result['pagination']['has_previous_page']);
-        $this->assertTrue($result['pagination']['has_next_page']);
+		// Assert has_previous_page and has_next_page are correct.
+		$this->assertTrue($result['pagination']['has_previous_page']);
+		$this->assertTrue($result['pagination']['has_next_page']);
 
-        // Use pagination to fetch previous page.
-        $result = $this->api->get_sequence_subscriptions(
-            $_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Sequence ID.
-            'active', // Subscriber state.
-            null, // Created after.
-            null, // Created before.
-            null, // Added after.
-            null, // Added before.
-            false, // Include total count.
-            '', // After cursor.
-            $result['pagination']['start_cursor'], // Before cursor.
-            1 // Per page.
-        ); 
+		// Use pagination to fetch previous page.
+		$result = $this->api->get_sequence_subscriptions(
+			$_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Sequence ID.
+			'active', // Subscriber state.
+			null, // Created after.
+			null, // Created before.
+			null, // Added after.
+			null, // Added before.
+			false, // Include total count.
+			'', // After cursor.
+			$result['pagination']['start_cursor'], // Before cursor.
+			1 // Per page.
+		);
 
-        // Assert subscribers and pagination exist.
-        $this->assertDataExists($result, 'subscribers');
-        $this->assertPaginationExists($result);
-    }
+		// Assert subscribers and pagination exist.
+		$this->assertDataExists($result, 'subscribers');
+		$this->assertPaginationExists($result);
+	}
 
-    /**
-     * Test that get_sequence_subscriptions() returns a WP_Error when an invalid
-     * Sequence ID is specified.
-     *
-     * @since   1.0.0
-     *
-     * @return void
-     */
-    public function testGetSequenceSubscriptionsWithInvalidSequenceID()
-    {
-        $result = $this->api->get_sequence_subscriptions(12345);
-        $this->assertInstanceOf(WP_Error::class, $result);
+	/**
+	 * Test that get_sequence_subscriptions() returns a WP_Error when an invalid
+	 * Sequence ID is specified.
+	 *
+	 * @since   1.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetSequenceSubscriptionsWithInvalidSequenceID()
+	{
+		$result = $this->api->get_sequence_subscriptions(12345);
+		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
-    }
+	}
 
-    /**
-     * Test that get_sequence_subscriptions() returns a WP_Error when an invalid
-     * subscriber state is specified.
-     *
-     * @since   2.0.0
-     *
-     * @return void
-     */
-    public function testGetSequenceSubscriptionsWithInvalidSubscriberState()
-    {
-        $result = $this->api->get_sequence_subscriptions(
-            (int) $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
-            'not-a-valid-state'
-        );
-        $this->assertInstanceOf(WP_Error::class, $result);
+	/**
+	 * Test that get_sequence_subscriptions() returns a WP_Error when an invalid
+	 * subscriber state is specified.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetSequenceSubscriptionsWithInvalidSubscriberState()
+	{
+		$result = $this->api->get_sequence_subscriptions(
+			(int) $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+			'not-a-valid-state'
+		);
+		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
-    }
+	}
 
-    /**
-     * Test that get_sequence_subscriptions() returns a WP_Error when invalid
-     * pagination parameters are specified.
-     *
-     * @since   2.0.0
-     *
-     * @return void
-     */
-    public function testGetSequenceSubscriptionsWithInvalidPagination()
-    {
-        $result = $this->api->get_sequence_subscriptions(
-            (int) $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
-            'not-a-valid-cursor'
-        );
-        $this->assertInstanceOf(WP_Error::class, $result);
+	/**
+	 * Test that get_sequence_subscriptions() returns a WP_Error when invalid
+	 * pagination parameters are specified.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetSequenceSubscriptionsWithInvalidPagination()
+	{
+		$result = $this->api->get_sequence_subscriptions(
+			(int) $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+			'not-a-valid-cursor'
+		);
+		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
-    }
+	}
 
 	/**
 	 * Test that the `get_tags()` function returns expected data.


### PR DESCRIPTION
## Summary

Adds tests for endpoints in the `Sequences` section of the v4 API, as we have in the PHP SDK.

Adds a new `get_error_message_string` method to the API class, to build an error message string based on the API response shape.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)