### PR TITLE
v4 API: Tests: Forms and Landing Pages

### DIFF
--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -934,7 +934,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 
 		// Assert has_previous_page and has_next_page are correct.
 		$this->assertTrue($result['pagination']['has_previous_page']);
-		$this->assertTrue($result['pagination']['has_next_page']);
+		$this->assertFalse($result['pagination']['has_next_page']);
 
 		// Use pagination to fetch previous page.
 		$result = $this->api->get_landing_pages('active', false, '', $result['pagination']['start_cursor'], 1);

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -743,7 +743,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 			// Assert form is not a landing page i.e embed.
 			$this->assertEquals($form['type'], 'embed');
 
-			// Assert form is not archived.
+			// Assert form is archived.
 			$this->assertTrue($form['archived']);
 		}
 	}


### PR DESCRIPTION
## Summary

Adds tests for endpoints in the `Forms` section of the v4 API, as we have in the PHP SDK.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)