### PR TITLE
v4 API: Add `form_subscribe`, `sequence_subscribe` and `tag_subscribe` methods

### DIFF
--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -508,7 +508,7 @@ class ConvertKit_API {
 			return $subscriber;
 		}
 
-		// Add subscriber to form.
+		// Add subscriber to tag.
 		return $this->tag_subscriber( $tag_id, $subscriber['subscriber']['id'] );
 
 	}

--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -498,7 +498,7 @@ class ConvertKit_API {
 	public function tag_subscribe( $tag_id, $email ) {
 
 		// Create subscriber.
-		$subscriber = $this->create_subscriber( $email, $first_name );
+		$subscriber = $this->create_subscriber( $email );
 
 		// Bail if an error occured.
 		if ( is_wp_error( $subscriber ) ) {

--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -463,19 +463,19 @@ class ConvertKit_API {
 
 	/**
 	 * Creates the given subscriber, assiging them to the given ConvertKit Form.
-	 * 
+	 *
 	 * @since  1.0.0
-	 * 
-	 * @param 	int 	$form_id 		Form ID.
-	 * @param 	string  $email      	Email Address.
-	 * @param   string  $first_name 	First Name.
-	 * @param   array   $custom_fields  Custom Fields.
+	 *
+	 * @param   int    $form_id        Form ID.
+	 * @param   string $email          Email Address.
+	 * @param   string $first_name     First Name.
+	 * @param   array  $custom_fields  Custom Fields.
 	 * @return  WP_Error|array
 	 */
 	public function form_subscribe( $form_id, $email, $first_name = '', $custom_fields = array() ) {
 
 		// Create subscriber.
-		$subscriber = $this->create_subscriber( $email, $first_name , 'active', $custom_fields );
+		$subscriber = $this->create_subscriber( $email, $first_name, 'active', $custom_fields );
 
 		// Bail if an error occured.
 		if ( is_wp_error( $subscriber ) ) {
@@ -489,19 +489,19 @@ class ConvertKit_API {
 
 	/**
 	 * Creates the given subscriber, assiging them to the given ConvertKit Tag.
-	 * 
+	 *
 	 * @since  1.0.0
-	 * 
-	 * @param 	int 	$tag_id 		Tag ID.
-	 * @param 	string  $email      	Email Address.
-	 * @param   string  $first_name 	First Name.
-	 * @param   array   $custom_fields  Custom Fields.
+	 *
+	 * @param   int    $tag_id         Tag ID.
+	 * @param   string $email          Email Address.
+	 * @param   string $first_name     First Name.
+	 * @param   array  $custom_fields  Custom Fields.
 	 * @return  WP_Error|array
 	 */
 	public function tag_subscribe( $tag_id, $email, $first_name = '', $custom_fields = array() ) {
 
 		// Create subscriber.
-		$subscriber = $this->create_subscriber( $email, $first_name , 'active', $custom_fields );
+		$subscriber = $this->create_subscriber( $email, $first_name, 'active', $custom_fields );
 
 		// Bail if an error occured.
 		if ( is_wp_error( $subscriber ) ) {
@@ -515,19 +515,19 @@ class ConvertKit_API {
 
 	/**
 	 * Creates the given subscriber, assiging them to the given ConvertKit Sequence.
-	 * 
+	 *
 	 * @since  1.0.0
-	 * 
-	 * @param 	int 	$sequence_id 	Sequence ID.
-	 * @param 	string  $email      	Email Address.
-	 * @param   string  $first_name 	First Name.
-	 * @param   array   $custom_fields  Custom Fields.
+	 *
+	 * @param   int    $sequence_id    Sequence ID.
+	 * @param   string $email          Email Address.
+	 * @param   string $first_name     First Name.
+	 * @param   array  $custom_fields  Custom Fields.
 	 * @return  WP_Error|array
 	 */
 	public function sequence_subscribe( $sequence_id, $email, $first_name = '', $custom_fields = array() ) {
 
 		// Create subscriber.
-		$subscriber = $this->create_subscriber( $email, $first_name , 'active', $custom_fields );
+		$subscriber = $this->create_subscriber( $email, $first_name, 'active', $custom_fields );
 
 		// Bail if an error occured.
 		if ( is_wp_error( $subscriber ) ) {

--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -462,6 +462,55 @@ class ConvertKit_API {
 	}
 
 	/**
+	 * Creates the given subscriber, assiging them to the given ConvertKit Form.
+	 * 
+	 * @since  1.0.0
+	 * 
+	 * @param 	int 	$form_id 	Form ID.
+	 * @param 	string  $email      Email Address.
+	 * @param   string  $first_name First Name.
+	 * @return  WP_Error|array
+	 */
+	public function form_subscribe( $form_id, $email, $first_name = '' ) {
+
+		// Create subscriber.
+		$subscriber = $this->create_subscriber( $email, $first_name );
+
+		// Bail if an error occured.
+		if ( is_wp_error( $subscriber ) ) {
+			return $subscriber;
+		}
+
+		// Add subscriber to form.
+		return $this->add_subscriber_to_form( $form_id, $subscriber['subscriber']['id'] );
+
+	}
+
+	/**
+	 * Creates the given subscriber, assiging them to the given ConvertKit Tag.
+	 * 
+	 * @since  1.0.0
+	 * 
+	 * @param 	int 	$tag_id 	Tag ID.
+	 * @param 	string  $email      Email Address.
+	 * @return  WP_Error|array
+	 */
+	public function tag_subscribe( $tag_id, $email ) {
+
+		// Create subscriber.
+		$subscriber = $this->create_subscriber( $email, $first_name );
+
+		// Bail if an error occured.
+		if ( is_wp_error( $subscriber ) ) {
+			return $subscriber;
+		}
+
+		// Add subscriber to form.
+		return $this->tag_subscriber( $tag_id, $subscriber['subscriber']['id'] );
+
+	}
+
+	/**
 	 * Get the ConvertKit subscriber ID associated with email address if it exists.
 	 * Return false if subscriber not found.
 	 *

--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -466,15 +466,16 @@ class ConvertKit_API {
 	 * 
 	 * @since  1.0.0
 	 * 
-	 * @param 	int 	$form_id 	Form ID.
-	 * @param 	string  $email      Email Address.
-	 * @param   string  $first_name First Name.
+	 * @param 	int 	$form_id 		Form ID.
+	 * @param 	string  $email      	Email Address.
+	 * @param   string  $first_name 	First Name.
+	 * @param   array   $custom_fields  Custom Fields.
 	 * @return  WP_Error|array
 	 */
-	public function form_subscribe( $form_id, $email, $first_name = '' ) {
+	public function form_subscribe( $form_id, $email, $first_name = '', $custom_fields = array() ) {
 
 		// Create subscriber.
-		$subscriber = $this->create_subscriber( $email, $first_name );
+		$subscriber = $this->create_subscriber( $email, $first_name , 'active', $custom_fields );
 
 		// Bail if an error occured.
 		if ( is_wp_error( $subscriber ) ) {
@@ -491,14 +492,16 @@ class ConvertKit_API {
 	 * 
 	 * @since  1.0.0
 	 * 
-	 * @param 	int 	$tag_id 	Tag ID.
-	 * @param 	string  $email      Email Address.
+	 * @param 	int 	$tag_id 		Tag ID.
+	 * @param 	string  $email      	Email Address.
+	 * @param   string  $first_name 	First Name.
+	 * @param   array   $custom_fields  Custom Fields.
 	 * @return  WP_Error|array
 	 */
-	public function tag_subscribe( $tag_id, $email ) {
+	public function tag_subscribe( $tag_id, $email, $first_name = '', $custom_fields = array() ) {
 
 		// Create subscriber.
-		$subscriber = $this->create_subscriber( $email );
+		$subscriber = $this->create_subscriber( $email, $first_name , 'active', $custom_fields );
 
 		// Bail if an error occured.
 		if ( is_wp_error( $subscriber ) ) {
@@ -507,6 +510,32 @@ class ConvertKit_API {
 
 		// Add subscriber to form.
 		return $this->tag_subscriber( $tag_id, $subscriber['subscriber']['id'] );
+
+	}
+
+	/**
+	 * Creates the given subscriber, assiging them to the given ConvertKit Sequence.
+	 * 
+	 * @since  1.0.0
+	 * 
+	 * @param 	int 	$sequence_id 	Sequence ID.
+	 * @param 	string  $email      	Email Address.
+	 * @param   string  $first_name 	First Name.
+	 * @param   array   $custom_fields  Custom Fields.
+	 * @return  WP_Error|array
+	 */
+	public function sequence_subscribe( $sequence_id, $email, $first_name = '', $custom_fields = array() ) {
+
+		// Create subscriber.
+		$subscriber = $this->create_subscriber( $email, $first_name , 'active', $custom_fields );
+
+		// Bail if an error occured.
+		if ( is_wp_error( $subscriber ) ) {
+			return $subscriber;
+		}
+
+		// Add subscriber to sequence.
+		return $this->add_subscriber_to_sequence( $sequence_id, $subscriber['subscriber']['id'] );
 
 	}
 

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -4580,7 +4580,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the `form_subscribe()` function returns the expected data.
-	 * 
+	 *
 	 * @since   2.0.0
 	 *
 	 * @return void
@@ -4589,7 +4589,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	{
 		// Make request.
 		$emailAddress = $this->generateEmailAddress();
-		$result = $this->api->form_subscribe(
+		$result       = $this->api->form_subscribe(
 			$_ENV['CONVERTKIT_API_FORM_ID'],
 			$emailAddress,
 			'First',
@@ -4606,9 +4606,174 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$this->assertArrayHasKey('subscriber', $result);
 		$this->assertArrayHasKey('email_address', $result['subscriber']);
 		$this->assertEquals($emailAddress, $result['subscriber']['email_address']);
+	}
 
-		// Assert subscriber assigned to form.
-		
+	/**
+	 * Test that the `form_subscribe()` function returns a WP_Error
+	 * when an invalid Form ID is specified.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testFormSubscribeWithInvalidFormID()
+	{
+		$result = $this->api->form_subscribe(
+			12345,
+			$this->generateEmailAddress()
+		);
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+	}
+
+	/**
+	 * Test that the `form_subscribe()` function returns a WP_Error
+	 * when an invalid email address is specified.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testFormSubscribeWithInvalidEmailAddress()
+	{
+		$result = $this->api->form_subscribe(
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			'not-a-valid-email'
+		);
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+	}
+
+	/**
+	 * Test that the `tag_subscribe()` function returns the expected data.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testTagSubscribe()
+	{
+		// Make request.
+		$emailAddress = $this->generateEmailAddress();
+		$result       = $this->api->tag_subscribe(
+			$_ENV['CONVERTKIT_API_TAG_ID'],
+			$emailAddress,
+			'First',
+			[
+				'last_name' => 'Last',
+			]
+		);
+
+		// Test array was returned.
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+
+		// Assert subscriber created.
+		$this->assertArrayHasKey('subscriber', $result);
+		$this->assertArrayHasKey('email_address', $result['subscriber']);
+		$this->assertEquals($emailAddress, $result['subscriber']['email_address']);
+	}
+
+	/**
+	 * Test that the `tag_subscribe()` function returns a WP_Error
+	 * when an invalid Tag ID is specified.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testTagSubscribeWithInvalidTagID()
+	{
+		$result = $this->api->tag_subscribe(
+			12345,
+			$this->generateEmailAddress()
+		);
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+	}
+
+	/**
+	 * Test that the `form_subscribe()` function returns a WP_Error
+	 * when an invalid email address is specified.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testTagSubscribeWithInvalidEmailAddress()
+	{
+		$result = $this->api->tag_subscribe(
+			$_ENV['CONVERTKIT_API_TAG_ID'],
+			'not-a-valid-email'
+		);
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+	}
+
+	/**
+	 * Test that the `sequence_subscribe()` function returns the expected data.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testSequenceSubscribe()
+	{
+		// Make request.
+		$emailAddress = $this->generateEmailAddress();
+		$result       = $this->api->sequence_subscribe(
+			$_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+			$emailAddress,
+			'First',
+			[
+				'last_name' => 'Last',
+			]
+		);
+
+		// Test array was returned.
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+
+		// Assert subscriber created.
+		$this->assertArrayHasKey('subscriber', $result);
+		$this->assertArrayHasKey('email_address', $result['subscriber']);
+		$this->assertEquals($emailAddress, $result['subscriber']['email_address']);
+	}
+
+	/**
+	 * Test that the `sequence_subscribe()` function returns a WP_Error
+	 * when an invalid Tag ID is specified.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testSequenceSubscribeWithInvalidTagID()
+	{
+		$result = $this->api->sequence_subscribe(
+			12345,
+			$this->generateEmailAddress()
+		);
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+	}
+
+	/**
+	 * Test that the `sequence_subscribe()` function returns a WP_Error
+	 * when an invalid email address is specified.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testSequenceSubscribeWithInvalidEmailAddress()
+	{
+		$result = $this->api->sequence_subscribe(
+			$_ENV['CONVERTKIT_API_TAG_ID'],
+			'not-a-valid-email'
+		);
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
 	}
 
 	/**

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -4579,6 +4579,39 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
+	 * Test that the `form_subscribe()` function returns the expected data.
+	 * 
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testFormSubscribe()
+	{
+		// Make request.
+		$emailAddress = $this->generateEmailAddress();
+		$result = $this->api->form_subscribe(
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$emailAddress,
+			'First',
+			[
+				'last_name' => 'Last',
+			]
+		);
+
+		// Test array was returned.
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+
+		// Assert subscriber created.
+		$this->assertArrayHasKey('subscriber', $result);
+		$this->assertArrayHasKey('email_address', $result['subscriber']);
+		$this->assertEquals($emailAddress, $result['subscriber']['email_address']);
+
+		// Assert subscriber assigned to form.
+		
+	}
+
+	/**
 	 * Test that the `get_posts()` function returns expected data.
 	 *
 	 * @since   1.0.0


### PR DESCRIPTION
## Summary

The ConvertKit Plugin has functionality which:
- creates a subscriber, assigning them to a form, when using Contact Form 7, Forminator, WPForms or other third party WordPress Form Plugins,
- creates a subscriber, tagging them, when using the `Add a Tag` functionality on a WordPress Page.

The ConvertKit for WooCommerce Plugin has functionality which:
- creates a subscriber, assigning them to a sequence.

In the v3 API, creating a new subscriber could only be performed by subscribing them to a Form, Tag or Sequence.  In v4, a subscriber is created using the `create_subscriber` method.  Subscribing them to a Form, Tag or Sequence is optional as a separate API call.

To minimise code changes and ensure backward compatibility with our WordPress Plugins, this PR adds the compatible methods for `form_subscribe`, `tag_subscribe` and `sequence_subscribe`, which:
- call `create_subscriber`
- call the applicable API method to subscribe them to a Form, Tag or Sequence.

## Testing

Tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)