### PR TITLE
v4 API: Tests: Run `wordpress` endpoint tests

### DIFF
--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -24,13 +24,6 @@ class ConvertKit_API {
 	public const VERSION = '2.0.0';
 
 	/**
-	 * ConvertKit API Key
-	 *
-	 * @var bool|string
-	 */
-	protected $api_key = false;
-
-	/**
 	 * Redirect URI.
 	 *
 	 * @var     bool|string
@@ -885,21 +878,38 @@ class ConvertKit_API {
 	}
 
 	/**
+	 * Returns the recommendations script URL for this account from the API,
+	 * used to display the Creator Network modal when a form is submitted.
+	 *
+	 * @since   1.3.7
+	 *
+	 * @return  WP_Error|array
+	 */
+	public function recommendations_script() {
+
+		$this->log( 'API: recommendations_script()' );
+
+		return $this->get( 'recommendations_script' );
+
+	}
+
+	/**
 	 * Get HTML from ConvertKit for the given Legacy Form ID.
 	 *
 	 * This isn't specifically an API function, but for now it's best suited here.
 	 *
-	 * @param   int $id     Form ID.
-	 * @return  WP_Error|string     HTML
+	 * @param   int    $id         Form ID.
+	 * @param   string $api_key    API Key.
+	 * @return  WP_Error|string             HTML
 	 */
-	public function get_form_html( $id ) {
+	public function get_form_html( $id, $api_key = '' ) {
 
 		$this->log( 'API: get_form_html(): [ id: ' . $id . ']' );
 
 		// Define Legacy Form URL.
 		$url = add_query_arg(
 			array(
-				'k' => $this->api_key,
+				'k' => $api_key,
 				'v' => 2,
 			),
 			'https://api.convertkit.com/forms/' . $id . '/embed'

--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -690,7 +690,35 @@ class ConvertKit_API {
 	 */
 	public function get_products() {
 
-		return $this->get( 'products' );
+		$this->log( 'API: get_products()' );
+
+		$products = array();
+
+		$response = $this->get( 'products' );
+
+		// If an error occured, log and return it now.
+		if ( is_wp_error( $response ) ) {
+			$this->log( 'API: get_products(): Error: ' . $response->get_error_message() );
+			return $response;
+		}
+
+		// If the response isn't an array as we expect, log that no products exist and return a blank array.
+		if ( ! is_array( $response['products'] ) ) {
+			$this->log( 'API: get_products(): Error: No products exist in ConvertKit.' );
+			return new WP_Error( 'convertkit_api_error', $this->get_error_message( 'response_type_unexpected' ) );
+		}
+
+		// If no products exist, log that no products exist and return a blank array.
+		if ( ! count( $response['products'] ) ) {
+			$this->log( 'API: get_products(): Error: No products exist in ConvertKit.' );
+			return $products;
+		}
+
+		foreach ( $response['products'] as $product ) {
+			$products[ $product['id'] ] = $product;
+		}
+
+		return $products;
 
 	}
 

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -4585,8 +4585,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testGetPosts()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api->get_posts();
 
 		// Test array was returned.
@@ -4615,8 +4613,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testGetPostsNoData()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api_no_data->get_posts();
 		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertIsArray($result);
@@ -4631,8 +4627,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testGetPostsWithValidParameters()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api->get_posts(1, 2);
 
 		// Test array was returned.
@@ -4664,8 +4658,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testGetPostsWithInvalidPageParameter()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api->get_posts(0);
 		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -4680,8 +4672,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testGetPostsWithNegativePerPageParameter()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api->get_posts(1, 0);
 		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -4696,8 +4686,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testGetPostsWithOutOfBoundsPerPageParameter()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api->get_posts(1, 100);
 		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -4711,8 +4699,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testGetAllPosts()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api->get_all_posts();
 		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertIsArray($result);
@@ -4731,8 +4717,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testGetAllPostsNoData()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api_no_data->get_all_posts();
 		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertIsArray($result);
@@ -4747,8 +4731,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testGetAllPostsWithValidParameters()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api->get_all_posts(2); // Number of posts to fetch in each request within the function.
 		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertIsArray($result);
@@ -4768,8 +4750,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testGetAllPostsWithInvalidPostsPerRequestParameter()
 	{
-		$this->markTestIncomplete();
-
 		// Test with a number less than 1.
 		$result = $this->api->get_all_posts(0);
 		$this->assertInstanceOf(WP_Error::class, $result);
@@ -4790,8 +4770,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testGetPostByID()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api->get_post($_ENV['CONVERTKIT_API_POST_ID']);
 		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertIsArray($result);
@@ -4815,8 +4793,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testGetPostByInvalidID()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api->get_post(12345);
 		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -4830,8 +4806,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testGetProducts()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api->get_products();
 		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertIsArray($result);
@@ -4849,8 +4823,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testGetProductsNoData()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api_no_data->get_forms();
 		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertIsArray($result);
@@ -4865,8 +4837,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testSubscriberAuthenticationSendCodeWithSubscribedEmail()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api->subscriber_authentication_send_code(
 			$_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL'],
 			$_ENV['TEST_SITE_WP_URL']
@@ -4882,8 +4852,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testSubscriberAuthenticationSendCodeWithNotSubscribedEmail()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api->subscriber_authentication_send_code(
 			'email-not-subscribed@convertkit.com',
 			$_ENV['TEST_SITE_WP_URL']
@@ -4901,8 +4869,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testSubscriberAuthenticationSendCodeWithNoEmail()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api->subscriber_authentication_send_code(
 			'',
 			$_ENV['TEST_SITE_WP_URL']
@@ -4920,8 +4886,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testSubscriberAuthenticationSendCodeWithInvalidEmail()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api->subscriber_authentication_send_code(
 			'not-an-email-address',
 			$_ENV['TEST_SITE_WP_URL']
@@ -4939,8 +4903,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testSubscriberAuthenticationSendCodeWithInvalidRedirectURL()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api->subscriber_authentication_send_code(
 			$_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL'],
 			'not-a-valid-url'
@@ -4958,8 +4920,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testSubscriberAuthenticationVerifyWithValidTokenAndInvalidSubscriberCode()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api->subscriber_authentication_verify(
 			$_ENV['CONVERTKIT_API_SUBSCRIBER_TOKEN'],
 			'subscriberCode'
@@ -4977,8 +4937,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testSubscriberAuthenticationVerifyWithNoToken()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api->subscriber_authentication_verify(
 			'',
 			'subscriberCode'
@@ -4996,8 +4954,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testSubscriberAuthenticationVerifyWithNoSubscriberCode()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api->subscriber_authentication_verify(
 			'token',
 			''
@@ -5015,8 +4971,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testSubscriberAuthenticationVerifyWithInvalidTokenAndSubscriberCode()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api->subscriber_authentication_verify(
 			'invalidToken',
 			'invalidSubscriberCode'
@@ -5035,8 +4989,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testProfilesWithValidSignedSubscriberID()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api->profile( $_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID'] );
 		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertIsArray($result);
@@ -5053,8 +5005,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testProfilesWithInvalidSignedSubscriberID()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api->profile('fakeSignedID');
 		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -5069,8 +5019,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testProfilesWithNoSignedSubscriberID()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api->profile('');
 		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -5429,8 +5377,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testRecommendationsScript()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api->recommendations_script();
 		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertIsArray($result);
@@ -5448,8 +5394,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testRecommendationsScriptWhenCreatorNetworkDisabled()
 	{
-		$this->markTestIncomplete();
-
 		$api    = new ConvertKit_API($_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
 		$result = $api->recommendations_script();
 		$this->assertNotInstanceOf(WP_Error::class, $result);
@@ -5468,8 +5412,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testGetLegacyFormHTML()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api->get_form_html($_ENV['CONVERTKIT_API_LEGACY_FORM_ID']);
 		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertStringContainsString('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">', $result);
@@ -5489,8 +5431,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testGetLegacyFormHTMLWithInvalidFormID()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api->get_form_html('11111');
 		$this->assertInstanceOf(WP_Error::class, $result);
 	}
@@ -5503,8 +5443,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testGetLandingPageHTML()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api->get_landing_page_html($_ENV['CONVERTKIT_API_LANDING_PAGE_URL']);
 		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertStringContainsString('<form method="POST" action="https://app.convertkit.com/forms/' . $_ENV['CONVERTKIT_API_LANDING_PAGE_ID'] . '/subscriptions" data-sv-form="' . $_ENV['CONVERTKIT_API_LANDING_PAGE_ID'] . '" data-uid="99f1db6843" class="formkit-form"', $result);
@@ -5518,8 +5456,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testGetLandingPageWithCharacterEncodingHTML()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api->get_landing_page_html($_ENV['CONVERTKIT_API_LANDING_PAGE_CHARACTER_ENCODING_URL']);
 		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertStringContainsString('<form method="POST" action="https://app.convertkit.com/forms/' . $_ENV['CONVERTKIT_API_LANDING_PAGE_CHARACTER_ENCODING_ID'] . '/subscriptions" data-sv-form="' . $_ENV['CONVERTKIT_API_LANDING_PAGE_CHARACTER_ENCODING_ID'] . '" data-uid="cc5eb21744" class="formkit-form"', $result);
@@ -5536,8 +5472,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testGetLegacyLandingPageHTML()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api->get_landing_page_html($_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_URL']);
 		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertStringContainsString('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://app.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_ID'] . '/subscribe" data-remote="true">', $result);
@@ -5551,134 +5485,8 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testGetLandingPageHTMLWithInvalidLandingPageURL()
 	{
-		$this->markTestIncomplete();
-
 		$result = $this->api->get_landing_page_html('http://fake-url');
 		$this->assertInstanceOf(WP_Error::class, $result);
-	}
-
-	/**
-	 * Test that the `get_subscriber()` function is backward compatible.
-	 *
-	 * @since   1.0.0
-	 */
-	public function testBackwardCompatGetSubscriber()
-	{
-		$this->markTestIncomplete();
-
-		$result = $this->api->get_subscriber($_ENV['CONVERTKIT_API_SUBSCRIBER_ID']);
-		$this->assertNotInstanceOf(WP_Error::class, $result);
-	}
-
-	/**
-	 * Test that the `add_tag()` function is backward compatible.
-	 *
-	 * @since   1.0.0
-	 */
-	public function testBackwardCompatAddTag()
-	{
-		$this->markTestIncomplete();
-
-		$result = $this->api->add_tag(
-			$_ENV['CONVERTKIT_API_TAG_ID'],
-			[
-				'email' => $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL'],
-			]
-		);
-		$this->assertNotInstanceOf(WP_Error::class, $result);
-		$this->assertIsArray($result);
-		$this->assertArrayHasKey('subscription', $result);
-	}
-
-	/**
-	 * Test that the `add_tag()` function is backward compatible and returns a WP_Error
-	 * when an empty $tag_id parameter is provided.
-	 *
-	 * @since   1.0.0
-	 */
-	public function testBackwardCompatAddTagWithEmptyTagID()
-	{
-		$this->markTestIncomplete();
-
-		$result = $this->api->add_tag(
-			'',
-			[
-				'email' => $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL'],
-			]
-		);
-		$this->assertInstanceOf(WP_Error::class, $result);
-		$this->assertEquals($result->get_error_code(), $this->errorCode);
-		$this->assertEquals('tag_subscribe(): the tag_id parameter is empty.', $result->get_error_message());
-	}
-
-	/**
-	 * Test that the `add_tag()` function is backward compatible and returns a WP_Error
-	 * when an empty $email parameter is provided.
-	 *
-	 * @since   1.0.0
-	 */
-	public function testBackwardCompatAddTagWithEmptyEmail()
-	{
-		$this->markTestIncomplete();
-
-		$result = $this->api->add_tag(
-			$_ENV['CONVERTKIT_API_TAG_ID'],
-			[
-				'email' => '',
-			]
-		);
-		$this->assertInstanceOf(WP_Error::class, $result);
-		$this->assertEquals($result->get_error_code(), $this->errorCode);
-		$this->assertEquals('tag_subscribe(): the email parameter is empty.', $result->get_error_message());
-	}
-
-	/**
-	 * Test that the `unsubscribe()` function is backward compatible.
-	 *
-	 * @since   1.0.0
-	 */
-	public function testBackwardCompatFormUnsubscribe()
-	{
-		$this->markTestIncomplete();
-
-		// We don't use $_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL'] for this test, as that email is relied upon as being a confirmed subscriber
-		// for other tests.
-
-		// Subscribe an email address.
-		$emailAddress = 'wordpress-' . date( 'Y-m-d-H-i-s' ) . '-php-' . PHP_VERSION_ID . '@convertkit.com';
-		$this->api->form_subscribe($_ENV['CONVERTKIT_API_FORM_ID'], $emailAddress);
-
-		// Unsubscribe the email address.
-		$result = $this->api->form_unsubscribe(
-			[
-				'email' => $emailAddress,
-			]
-		);
-		$this->assertNotInstanceOf(WP_Error::class, $result);
-		$this->assertIsArray($result);
-		$this->assertArrayHasKey('subscriber', $result);
-		$this->assertArrayHasKey('email_address', $result['subscriber']);
-		$this->assertEquals($emailAddress, $result['subscriber']['email_address']);
-	}
-
-	/**
-	 * Test that the `unsubscribe()` function is backward compatible and returns a WP_Error
-	 * when an empty $email parameter is provided.
-	 *
-	 * @since   1.0.0
-	 */
-	public function testBackwardCompatFormUnsubscribeWithEmptyEmail()
-	{
-		$this->markTestIncomplete();
-
-		$result = $this->api->form_unsubscribe(
-			[
-				'email' => '',
-			]
-		);
-		$this->assertInstanceOf(WP_Error::class, $result);
-		$this->assertEquals($result->get_error_code(), $this->errorCode);
-		$this->assertEquals('unsubscribe(): the email parameter is empty.', $result->get_error_message());
 	}
 
 	/**

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -4734,7 +4734,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$result = $this->api->get_all_posts(2); // Number of posts to fetch in each request within the function.
 		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertIsArray($result);
-		$this->assertCount(4, $result);
+		$this->assertCount(5, $result);
 		$this->assertArrayHasKey('id', reset($result));
 		$this->assertArrayHasKey('title', reset($result));
 		$this->assertArrayHasKey('url', reset($result));
@@ -4796,7 +4796,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$result = $this->api->get_post(12345);
 		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
-		$this->assertEquals('Post not found', $result->get_error_message());
 	}
 
 	/**
@@ -4823,7 +4822,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testGetProductsNoData()
 	{
-		$result = $this->api_no_data->get_forms();
+		$result = $this->api_no_data->get_products();
 		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertIsArray($result);
 		$this->assertCount(0, $result);
@@ -5008,7 +5007,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$result = $this->api->profile('fakeSignedID');
 		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
-		$this->assertEquals($result->get_error_message(), 'Subscriber not found');
 	}
 
 	/**
@@ -5022,7 +5020,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$result = $this->api->profile('');
 		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
-		$this->assertEquals($result->get_error_message(), 'profiles(): the signed_subscriber_id parameter is empty.');
 	}
 
 	/**

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -5391,8 +5391,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testRecommendationsScriptWhenCreatorNetworkDisabled()
 	{
-		$api    = new ConvertKit_API($_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
-		$result = $api->recommendations_script();
+		$result = $this->api_no_data->recommendations_script();
 		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertIsArray($result);
 		$this->assertArrayHasKey('enabled', $result);
@@ -5409,7 +5408,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testGetLegacyFormHTML()
 	{
-		$result = $this->api->get_form_html($_ENV['CONVERTKIT_API_LEGACY_FORM_ID']);
+		$result = $this->api->get_form_html($_ENV['CONVERTKIT_API_LEGACY_FORM_ID'], $_ENV['CONVERTKIT_API_KEY']);
 		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertStringContainsString('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://api.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '/subscribe" data-remote="true">', $result);
 
@@ -5428,7 +5427,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testGetLegacyFormHTMLWithInvalidFormID()
 	{
-		$result = $this->api->get_form_html('11111');
+		$result = $this->api->get_form_html('11111', $_ENV['CONVERTKIT_API_KEY']);
 		$this->assertInstanceOf(WP_Error::class, $result);
 	}
 


### PR DESCRIPTION
## Summary

Runs tests using the `wordpress` endpoint, that were previously marked as incomplete, resolving:
- Reinstating the missing `recommendations_script` method, that [previously existed](https://github.com/ConvertKit/convertkit-wordpress-libraries/blob/main/src/class-convertkit-api.php#L1564).
- Adding an `api_key` parameter to `get_form_html` for fetching legacy forms, as the v4 API does not use API Keys or list legacy forms. This method may be used by the main ConvertKit Plugin to support existing legacy forms that were previously defined in the Plugin or a shortcode/block.
- Removes `testBackwardCompat*` tests for methods that were marked deprecated in v1 of our WordPress Libraries, as these functions are removed in this v2 WordPress Library.

## Testing

Tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)