### PR TITLE
v4 API: Logging

### DIFF
--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -528,8 +528,6 @@ class ConvertKit_API {
 	 */
 	public function get_all_posts( $posts_per_request = 50 ) {
 
-		$this->log( 'API: get_all_posts()' );
-
 		// Sanitize some parameters.
 		$posts_per_request = absint( $posts_per_request );
 
@@ -592,8 +590,6 @@ class ConvertKit_API {
 	 */
 	public function get_posts( $page = 1, $per_page = 10 ) {
 
-		$this->log( 'API: get_posts()' );
-
 		// Sanitize some parameters.
 		$page     = absint( $page );
 		$per_page = absint( $per_page );
@@ -652,8 +648,6 @@ class ConvertKit_API {
 	 */
 	public function get_post( $post_id ) {
 
-		$this->log( 'API: get_post(): [ post_id: ' . $post_id . ']' );
-
 		// Send request.
 		$response = $this->get(
 			sprintf( 'posts/%s', $post_id ),
@@ -708,8 +702,6 @@ class ConvertKit_API {
 	 * @return  WP_Error|string
 	 */
 	public function subscriber_authentication_send_code( $email, $redirect_url ) {
-
-		$this->log( 'API: subscriber_authentication_send_code(): [ email: ' . $email . ', redirect_url: ' . $redirect_url . ']' );
 
 		// Sanitize some parameters.
 		$email        = trim( $email );
@@ -766,7 +758,6 @@ class ConvertKit_API {
 	 */
 	public function subscriber_authentication_verify( $token, $subscriber_code ) {
 
-		$this->log( 'API: subscriber_authentication_verify(): [ token: ' . $this->mask_string( $token ) . ', subscriber_code: ' . $this->mask_string( $subscriber_code ) . ']' );
 
 		// Sanitize some parameters.
 		$token           = trim( $token );
@@ -817,8 +808,6 @@ class ConvertKit_API {
 	 * @return  WP_Error|array
 	 */
 	public function profile( $signed_subscriber_id ) {
-
-		$this->log( 'API: profile(): [ signed_subscriber_id: ' . $this->mask_string( $signed_subscriber_id ) . ' ]' );
 
 		// Trim some parameters.
 		$signed_subscriber_id = trim( $signed_subscriber_id );
@@ -1071,6 +1060,14 @@ class ConvertKit_API {
 	 * @return  WP_Error|array|null
 	 */
 	public function request( $endpoint, $method = 'get', $params = array(), $retry_if_rate_limit_hit = true ) {
+
+		// Log request.
+        $this->log( sprintf(
+        	'API: %s %s [%s]',
+        	$method,
+        	$endpoint,
+        	wp_json_encode( $params )
+        ) );
 
 		// Send request.
 		switch ( strtolower( $method ) ) {

--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -1063,10 +1063,10 @@ class ConvertKit_API {
 
 		// Log request.
         $this->log( sprintf(
-        	'API: %s %s [%s]',
+        	'API: %s %s: %s',
         	$method,
         	$endpoint,
-        	wp_json_encode( $params )
+        	wp_json_encode( $this->mask_params( $params ) )
         ) );
 
 		// Send request.
@@ -1442,6 +1442,41 @@ class ConvertKit_API {
 
 		// Return error message.
 		return $this->error_messages[ $key ];
+
+	}
+
+	/**
+	 * Helper method to mask values for specific keys in an array.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @param   string $str    String to mask.
+	 * @return  string         Masked string
+	 */
+	private function mask_params( $params ) {
+
+		$keys = array(
+			'first_name',
+			'token',
+			'subscriber_code',
+			'signed_subscriber_id',
+		);
+
+		foreach ( $params as $key => $value ) {
+			// Skip if not a string
+			if ( ! is_string( $value ) ) {
+				continue;
+			}
+
+			// Skip if the key isn't one we need to mask the value of.
+			if ( ! in_array( $key, $keys ) ) {
+				continue;
+			}
+
+			$params[ $key ] = $this->mask_string( $value );
+		}
+
+		return $params;
 
 	}
 

--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -857,7 +857,6 @@ class ConvertKit_API {
 	 */
 	public function subscriber_authentication_verify( $token, $subscriber_code ) {
 
-
 		// Sanitize some parameters.
 		$token           = trim( $token );
 		$subscriber_code = trim( $subscriber_code );
@@ -1178,12 +1177,19 @@ class ConvertKit_API {
 	public function request( $endpoint, $method = 'get', $params = array(), $retry_if_rate_limit_hit = true ) {
 
 		// Log request.
-        $this->log( sprintf(
-        	'API: %s %s: %s',
-        	$method,
-        	$endpoint,
-        	wp_json_encode( $this->mask_params( $params ) )
-        ) );
+		$log = sprintf(
+			'API: %s %s',
+			$method,
+			$this->mask_endpoint( $endpoint )
+		);
+		if ( count( $params ) ) {
+			$log = sprintf(
+				'%s: %s',
+				$log,
+				wp_json_encode( $this->mask_params( $params ) )
+			);
+		}
+		$this->log( $log );
 
 		// Send request.
 		switch ( strtolower( $method ) ) {
@@ -1299,6 +1305,8 @@ class ConvertKit_API {
 					$error = $this->get_error_message( 'request_http_not_supported' );
 					break;
 			}
+
+			$this->log( 'API: Error: ' . $error );
 
 			return new WP_Error(
 				'convertkit_api_error',
@@ -1562,30 +1570,62 @@ class ConvertKit_API {
 	}
 
 	/**
+	 * Helper method to mask the given endpoint URL where it contains
+	 * sensitive data, such as a signed subscriber ID.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @param   string $endpoint    String to mask.
+	 * @return  string              Masked string
+	 */
+	private function mask_endpoint( $endpoint ) {
+
+		// Endpoints to mask string.
+		$keys = array(
+			'profile/',
+		);
+
+		foreach ( $keys as $key => $value ) {
+			// Skip if the endpoint isn't one we need to mask.
+			if ( strpos( $endpoint, $value ) === false ) {
+				continue;
+			}
+
+			// Mask after the key e.g. profile/******abcd.
+			return $value . $this->mask_string( str_replace( $value, '', $endpoint ) );
+
+		}
+
+		// Just return the endpoint, as it doesn't need masking.
+		return $endpoint;
+
+	}
+
+	/**
 	 * Helper method to mask values for specific keys in an array.
 	 *
 	 * @since   2.0.0
 	 *
-	 * @param   string $str    String to mask.
-	 * @return  string         Masked string
+	 * @param   array $params Array of parameters to mask.
+	 * @return  array          Array of parameters with masked values where applicable
 	 */
 	private function mask_params( $params ) {
 
+		// Keys to mask values for.
 		$keys = array(
 			'first_name',
 			'token',
 			'subscriber_code',
-			'signed_subscriber_id',
 		);
 
 		foreach ( $params as $key => $value ) {
-			// Skip if not a string
+			// Skip if not a string.
 			if ( ! is_string( $value ) ) {
 				continue;
 			}
 
 			// Skip if the key isn't one we need to mask the value of.
-			if ( ! in_array( $key, $keys ) ) {
+			if ( ! in_array( $key, $keys, true ) ) {
 				continue;
 			}
 

--- a/tests/wpunit/APINoDataTest.php
+++ b/tests/wpunit/APINoDataTest.php
@@ -238,7 +238,9 @@ class APINoDataTest extends \Codeception\TestCase\WPTestCase
 	public function testGetProducts()
 	{
 		$result = $this->api->get_products();
-		$this->assertNoData($result, 'products');
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertCount(0, $result);
 	}
 
 	/**

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -135,18 +135,23 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testLog()
 	{
-		$this->markTestIncomplete();
-
 		// Define location for log file.
 		define( 'CONVERTKIT_PLUGIN_PATH', $_ENV['WP_ROOT_FOLDER'] . '/wp-content/uploads' );
 
 		// Create a log.txt file.
 		$this->tester->writeToFile(CONVERTKIT_PLUGIN_PATH . '/log.txt', 'historical log file');
 
-		// Initialize API.
-		$api = new ConvertKit_API( $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'], true );
+		// Initialize API with logging enabled.
+		$api = new ConvertKit_API(
+			$_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
+			$_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
+			$_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
+			$_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN'],
+			true
+		);
 
 		// Perform actions that will write sensitive data to the log file.
+		/*
 		$api->form_subscribe(
 			$_ENV['CONVERTKIT_API_FORM_ID'],
 			$_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL'],
@@ -155,6 +160,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 				'last_name' => 'Last',
 			)
 		);
+		*/
 		$api->profile($_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID']);
 
 		// Confirm the historical log.txt file has been deleted.
@@ -168,7 +174,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 
 		// Confirm the contents of the log file have masked the email address, name and signed subscriber ID.
 		$this->tester->openFile(CONVERTKIT_PLUGIN_PATH . '/log/log.txt');
-		$this->tester->seeInThisFile('API: form_subscribe(): [ form_id: ' . $_ENV['CONVERTKIT_API_FORM_ID'] . ', email: o****@n********.c**, first_name: ******Name ]');
+		//$this->tester->seeInThisFile('API: form_subscribe(): [ form_id: ' . $_ENV['CONVERTKIT_API_FORM_ID'] . ', email: o****@n********.c**, first_name: ******Name ]');
 		$this->tester->seeInThisFile('API: profile(): [ signed_subscriber_id: ********************');
 		$this->tester->dontSeeInThisFile($_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']);
 		$this->tester->dontSeeInThisFile('First Name');

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -151,7 +151,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		);
 
 		// Perform actions that will write sensitive data to the log file.
-		/*
 		$api->form_subscribe(
 			$_ENV['CONVERTKIT_API_FORM_ID'],
 			$_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL'],
@@ -160,7 +159,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 				'last_name' => 'Last',
 			)
 		);
-		*/
 		$api->profile($_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID']);
 
 		// Confirm the historical log.txt file has been deleted.
@@ -174,8 +172,8 @@ class APITest extends \Codeception\TestCase\WPTestCase
 
 		// Confirm the contents of the log file have masked the email address, name and signed subscriber ID.
 		$this->tester->openFile(CONVERTKIT_PLUGIN_PATH . '/log/log.txt');
-		//$this->tester->seeInThisFile('API: form_subscribe(): [ form_id: ' . $_ENV['CONVERTKIT_API_FORM_ID'] . ', email: o****@n********.c**, first_name: ******Name ]');
-		$this->tester->seeInThisFile('API: profile(): [ signed_subscriber_id: ********************');
+		$this->tester->seeInThisFile('API: POST subscribers: {"email_address":"o****@n********.c**","first_name":"******Name","state":"active","fields":{"last_name":"Last"}}');
+		$this->tester->seeInThisFile('API: GET profile/*****************************************');
 		$this->tester->dontSeeInThisFile($_ENV['CONVERTKIT_API_SUBSCRIBER_EMAIL']);
 		$this->tester->dontSeeInThisFile('First Name');
 		$this->tester->dontSeeInThisFile($_ENV['CONVERTKIT_API_SIGNED_SUBSCRIBER_ID']);


### PR DESCRIPTION
## Summary

Improves logging, by:
- Adding a `log` call to the `request` method, ensuring all API requests are logged, with parameters where specified
- Masking sensitive values if included in the URL (building on #34)
- Removing duplicate `log` calls, now that the `request` method catches all API requests.

## Testing

- `testLog` reinstated and updated to confirm sensitive data is masked when written to the log file.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)