### PR TITLE
v4 API: PHPStan Compatibility

### DIFF
--- a/src/class-convertkit-api-traits.php
+++ b/src/class-convertkit-api-traits.php
@@ -65,7 +65,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#get-current-account
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function get_account()
     {
@@ -77,7 +77,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#list-colors
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function get_account_colors()
     {
@@ -91,7 +91,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#list-colors
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function update_account_colors(array $colors)
     {
@@ -106,7 +106,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#get-creator-profile
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function get_creator_profile()
     {
@@ -118,7 +118,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#get-email-stats
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function get_email_stats()
     {
@@ -133,7 +133,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#get-growth-stats
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function get_growth_stats(\DateTime $starting = null, \DateTime $ending = null)
     {
@@ -159,7 +159,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#convertkit-api-forms
      *
-     * @return false|array<int,\stdClass>
+     * @return WP_Error|array
      */
     public function get_forms(
         string $status = 'active',
@@ -196,7 +196,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#convertkit-api-forms
      *
-     * @return false|array<int,\stdClass>
+     * @return WP_Error|array
      */
     public function get_landing_pages(
         string $status = 'active',
@@ -228,7 +228,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#add-subscriber-to-form-by-email-address
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function add_subscriber_to_form_by_email(int $form_id, string $email_address)
     {
@@ -248,7 +248,7 @@ trait ConvertKit_API_Traits
      *
      * @since 2.0.0
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function add_subscriber_to_form(int $form_id, int $subscriber_id)
     {
@@ -271,7 +271,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#list-subscribers-for-a-form
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function get_form_subscriptions(
         int $form_id,
@@ -327,7 +327,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#list-sequences
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function get_sequences(
         bool $include_total_count = false,
@@ -355,7 +355,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#add-subscriber-to-sequence-by-email-address
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function add_subscriber_to_sequence_by_email(int $sequence_id, string $email_address)
     {
@@ -375,7 +375,7 @@ trait ConvertKit_API_Traits
      *
      * @since 2.0.0
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function add_subscriber_to_sequence(int $sequence_id, int $subscriber_id)
     {
@@ -398,7 +398,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#list-subscribers-for-a-sequence
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function get_sequence_subscriptions(
         int $sequence_id,
@@ -454,7 +454,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#list-tags
      *
-     * @return false|array<int,\stdClass>
+     * @return WP_Error|array
      */
     public function get_tags(
         bool $include_total_count = false,
@@ -483,7 +483,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#create-a-tag
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function create_tag(string $tag)
     {
@@ -503,7 +503,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#bulk-create-tags
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function create_tags(array $tags, string $callback_url = '')
     {
@@ -536,7 +536,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#tag-a-subscriber-by-email-address
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function tag_subscriber_by_email(int $tag_id, string $email_address)
     {
@@ -554,7 +554,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#tag-a-subscriber
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function tag_subscriber(int $tag_id, int $subscriber_id)
     {
@@ -571,7 +571,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#remove-tag-from-subscriber
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function remove_tag_from_subscriber(int $tag_id, int $subscriber_id)
     {
@@ -588,7 +588,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#remove-tag-from-subscriber-by-email-address
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function remove_tag_from_subscriber_by_email(int $tag_id, string $email_address)
     {
@@ -614,7 +614,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#list-subscribers-for-a-tag
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function get_tag_subscriptions(
         int $tag_id,
@@ -672,7 +672,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#convertkit-api-email-templates
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function get_email_templates(
         bool $include_total_count = false,
@@ -713,7 +713,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#list-subscribers
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function get_subscribers(
         string $subscriber_state = 'active',
@@ -852,7 +852,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#get-a-subscriber
      *
-     * @return false|integer
+     * @return bool|WP_Error|integer
      */
     public function get_subscriber_id(string $email_address)
     {
@@ -876,7 +876,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#get-a-subscriber
      *
-     * @return false|integer
+     * @return bool|WP_Error|array
      */
     public function get_subscriber(int $subscriber_id)
     {
@@ -893,7 +893,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#update-a-subscriber
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function update_subscriber(
         int $subscriber_id,
@@ -928,7 +928,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#unsubscribe-subscriber
      *
-     * @return false|object
+     * @return bool|WP_Error|array
      */
     public function unsubscribe_by_email(string $email_address)
     {
@@ -947,7 +947,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#unsubscribe-subscriber
      *
-     * @return false|object
+     * @return bool|WP_Error|array
      */
     public function unsubscribe(int $subscriber_id)
     {
@@ -965,7 +965,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#list-tags-for-a-subscriber
      *
-     * @return false|array<int,\stdClass>
+     * @return WP_Error|array
      */
     public function get_subscriber_tags(
         int $subscriber_id,
@@ -996,7 +996,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#list-broadcasts
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function get_broadcasts(
         bool $include_total_count = false,
@@ -1042,7 +1042,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#create-a-broadcast
      *
-     * @return false|object
+     * @return bool|WP_Error|array
      */
     public function create_broadcast(
         string $subject = '',
@@ -1101,7 +1101,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#get-a-broadcast
      *
-     * @return false|object
+     * @return bool|WP_Error|array
      */
     public function get_broadcast(int $id)
     {
@@ -1116,7 +1116,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#get-stats
      *
-     * @return false|object
+     * @return bool|WP_Error|array
      */
     public function get_broadcast_stats(int $id)
     {
@@ -1149,7 +1149,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/#create-a-broadcast
      *
-     * @return false|object
+     * @return bool|WP_Error|array
      */
     public function update_broadcast(
         int $id,
@@ -1211,7 +1211,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#delete-a-broadcast
      *
-     * @return false|object
+     * @return bool|WP_Error|array
      */
     public function delete_broadcast(int $id)
     {
@@ -1230,7 +1230,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#list-webhooks
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function get_webhooks(
         bool $include_total_count = false,
@@ -1264,7 +1264,7 @@ trait ConvertKit_API_Traits
      *
      * @throws \InvalidArgumentException If the event is not supported.
      *
-     * @return false|object
+     * @return bool|WP_Error|array
      */
     public function create_webhook(string $url, string $event, string $parameter = '')
     {
@@ -1338,7 +1338,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#delete-a-webhook
      *
-     * @return false|object
+     * @return bool|WP_Error|array
      */
     public function delete_webhook(int $id)
     {
@@ -1357,7 +1357,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#list-custom-fields
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function get_custom_fields(
         bool $include_total_count = false,
@@ -1387,7 +1387,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#create-a-custom-field
      *
-     * @return false|object
+     * @return bool|WP_Error|array
      */
     public function create_custom_field(string $label)
     {
@@ -1407,7 +1407,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#bulk-create-custom-fields
      *
-     * @return false|object
+     * @return bool|WP_Error|array
      */
     public function create_custom_fields(array $labels, string $callback_url = '')
     {
@@ -1442,7 +1442,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#update-a-custom-field
      *
-     * @return false|object
+     * @return bool|WP_Error|array
      */
     public function update_custom_field(int $id, string $label)
     {
@@ -1461,7 +1461,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/#destroy-field
      *
-     * @return false|object
+     * @return bool|WP_Error|array
      */
     public function delete_custom_field(int $id)
     {
@@ -1480,7 +1480,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#list-purchases
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function get_purchases(
         bool $include_total_count = false,
@@ -1508,7 +1508,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#get-a-purchase
      *
-     * @return false|object
+     * @return bool|WP_Error|array
      */
     public function get_purchase(int $purchase_id)
     {
@@ -1533,7 +1533,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#create-a-purchase
      *
-     * @return false|object
+     * @return bool|WP_Error|array
      */
     public function create_purchase(
         string $email_address,
@@ -1595,7 +1595,7 @@ trait ConvertKit_API_Traits
      *
      * @see https://developers.convertkit.com/v4.html#convertkit-api-segments
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function get_segments(
         bool $include_total_count = false,
@@ -1716,7 +1716,7 @@ trait ConvertKit_API_Traits
      * @param string                                                             $endpoint API Endpoint.
      * @param array<string, int|string|boolean|array<string, int|string>|string> $args     Request arguments.
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function get(string $endpoint, array $args = [])
     {
@@ -1729,7 +1729,7 @@ trait ConvertKit_API_Traits
      * @param string                                                                                                     $endpoint API Endpoint.
      * @param array<string, bool|integer|float|string|null|array<int|string, float|integer|string|array<string|string>>> $args     Request arguments.
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function post(string $endpoint, array $args = [])
     {
@@ -1742,7 +1742,7 @@ trait ConvertKit_API_Traits
      * @param string                                                              $endpoint API Endpoint.
      * @param array<string, bool|integer|string|array<string, int|string>|string> $args     Request arguments.
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function put(string $endpoint, array $args = [])
     {
@@ -1755,7 +1755,7 @@ trait ConvertKit_API_Traits
      * @param string                                                     $endpoint API Endpoint.
      * @param array<string, int|string|array<string, int|string>|string> $args     Request arguments.
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     public function delete(string $endpoint, array $args = [])
     {
@@ -1771,7 +1771,7 @@ trait ConvertKit_API_Traits
      *
      * @throws \Exception If JSON encoding arguments failed.
      *
-     * @return false|mixed
+     * @return WP_Error|array
      */
     abstract public function request(string $endpoint, string $method, array $args = []);
 


### PR DESCRIPTION
## Summary

Updates return types in docblocks to pass PHPStan compatibility when used in our WordPress Plugins, as we'll return:
- a `WP_Error` on a request / API error,
- an `array` instead of an object, when data is returned. 

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)