### PR TITLE
v4 API: Rename Exchange API Key and Secret Method

### DIFF
--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -442,7 +442,7 @@ class ConvertKit_API {
 	 * @param   string $api_secret API Secret.
 	 * @return  WP_Error|array
 	 */
-	public function exchange_api_key_and_secret_for_access_token( $api_key, $api_secret ) {
+	public function get_access_token_by_api_key_and_secret( $api_key, $api_secret ) {
 
 		return $this->post(
 			'accounts/oauth_access_token',

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -455,14 +455,14 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that exchanging a valid API Key and Secret for an Access Token returns the expected data.
+	 * Test that fetching an Access Token using a valid API Key and Secret returns the expected data.
 	 *
 	 * @since   2.0.0
 	 */
-	public function testExchangeAPIKeyAndSecretForAccessToken()
+	public function testGetAccessTokenByAPIKeyAndSecret()
 	{
 		$api    = new ConvertKit_API( $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'], $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'] );
-		$result = $api->exchange_api_key_and_secret_for_access_token(
+		$result = $api->get_access_token_by_api_key_and_secret(
 			$_ENV['CONVERTKIT_API_KEY'],
 			$_ENV['CONVERTKIT_API_SECRET']
 		);
@@ -475,14 +475,14 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that exchanging an invalid API Key and Secret for an Access Token returns a WP_Error.
+	 * Test that fetching an Access Token using an invalid API Key and Secret returns a WP_Error.
 	 *
 	 * @since   2.0.0
 	 */
-	public function testExchangeInvalidAPIKeyAndSecretForAccessToken()
+	public function testGetAccessTokenByInvalidAPIKeyAndSecret()
 	{
 		$api    = new ConvertKit_API( $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'], $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'] );
-		$result = $api->exchange_api_key_and_secret_for_access_token(
+		$result = $api->get_access_token_by_api_key_and_secret(
 			'invalid-api-key',
 			'invalid-api-secret'
 		);


### PR DESCRIPTION
## Summary

Renames the `exchange_api_key_and_secret_for_access_token` method to the more accurate name `get_access_token_by_api_key_and_secret`, as recommended [here](https://github.com/ConvertKit/convertkit-wordpress/pull/656#pullrequestreview-2058298439).

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)