### PR TITLE
v4 API: Mock Refresh Token Test

### DIFF
--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -442,7 +442,7 @@ class ConvertKit_API {
 	 * @param   string $api_secret API Secret.
 	 * @return  WP_Error|array
 	 */
-	public function exchange_api_key_and_secret_for_access_token( $api_key, $api_secret ) {
+	public function get_access_token_by_api_key_and_secret( $api_key, $api_secret ) {
 
 		return $this->post(
 			'accounts/oauth_access_token',

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -402,6 +402,24 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testRefreshToken()
 	{
+		// Add mock handler for this API request, as this results in a new
+		// access and refresh token being provided, which would result in
+		// other tests breaking due to changed tokens.
+		$this->mockResponses(
+			200,
+			'OK',
+			wp_json_encode(
+				array(
+					'access_token'  => $_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
+					'refresh_token' => $_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN'],
+					'token_type'    => 'bearer',
+					'created_at'    => strtotime( 'now' ),
+					'expires_in'    => 10000,
+					'scope'         => 'public',
+				)
+			)
+		);
+
 		// Send request.
 		$result = $this->api->refresh_token();
 

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -473,14 +473,14 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that exchanging a valid API Key and Secret for an Access Token returns the expected data.
+	 * Test that fetching an Access Token using a valid API Key and Secret returns the expected data.
 	 *
 	 * @since   2.0.0
 	 */
-	public function testExchangeAPIKeyAndSecretForAccessToken()
+	public function testGetAccessTokenByAPIKeyAndSecret()
 	{
 		$api    = new ConvertKit_API( $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'], $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'] );
-		$result = $api->exchange_api_key_and_secret_for_access_token(
+		$result = $api->get_access_token_by_api_key_and_secret(
 			$_ENV['CONVERTKIT_API_KEY'],
 			$_ENV['CONVERTKIT_API_SECRET']
 		);
@@ -493,14 +493,14 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that exchanging an invalid API Key and Secret for an Access Token returns a WP_Error.
+	 * Test that fetching an Access Token using an invalid API Key and Secret returns a WP_Error.
 	 *
 	 * @since   2.0.0
 	 */
-	public function testExchangeInvalidAPIKeyAndSecretForAccessToken()
+	public function testGetAccessTokenByInvalidAPIKeyAndSecret()
 	{
 		$api    = new ConvertKit_API( $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'], $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'] );
-		$result = $api->exchange_api_key_and_secret_for_access_token(
+		$result = $api->get_access_token_by_api_key_and_secret(
 			'invalid-api-key',
 			'invalid-api-secret'
 		);


### PR DESCRIPTION
## Summary

Mocks the `testRefreshToken` test, otherwise the newly issued access and refresh tokens (rightly) mean our existing access and refresh tokens stored in the .env file are invalidated, and therefore later tests fail.

<img width="662" alt="Screenshot 2024-05-16 at 16 11 27" src="https://github.com/ConvertKit/convertkit-wordpress-libraries/assets/1462305/111e9d90-373c-4c54-b041-f7bd08cfb0c9">

Previously, tests would pass without mocking this call.  Possibly a [change in doorkeeper 5.7.0](https://github.com/ConvertKit/convertkit/pull/28675) that revokes existing credentials / grants when refreshing an access token.

## Testing

Existing tests pass

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)