### PR TITLE
v4 API: Legacy Forms and Landing Pages

### DIFF
--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -651,68 +651,68 @@ class ConvertKit_API {
 	}
 
 	/**
-     * Get legacy forms.
-     *
-     * @param boolean $include_total_count To include the total count of records in the response, use true.
-     * @param string  $after_cursor        Return results after the given pagination cursor.
-     * @param string  $before_cursor       Return results before the given pagination cursor.
-     * @param integer $per_page            Number of results to return.
-     *
-     * @since 2.0.0
-     *
-     * @return WP_Error|array
-     */
-    public function get_legacy_forms(
-        bool $include_total_count = false,
-        string $after_cursor = '',
-        string $before_cursor = '',
-        int $per_page = 100
-    ) {
-        return $this->get(
-            'landing_pages',
-            $this->build_total_count_and_pagination_params(
-                [
-                    'type'   => 'embed',
-                ],
-                $include_total_count,
-                $after_cursor,
-                $before_cursor,
-                $per_page
-            )
-        );
-    }
+	 * Get legacy forms.
+	 *
+	 * @param boolean $include_total_count To include the total count of records in the response, use true.
+	 * @param string  $after_cursor        Return results after the given pagination cursor.
+	 * @param string  $before_cursor       Return results before the given pagination cursor.
+	 * @param integer $per_page            Number of results to return.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @return WP_Error|array
+	 */
+	public function get_legacy_forms(
+		bool $include_total_count = false,
+		string $after_cursor = '',
+		string $before_cursor = '',
+		int $per_page = 100
+	) {
+		return $this->get(
+			'landing_pages',
+			$this->build_total_count_and_pagination_params(
+				array(
+					'type' => 'embed',
+				),
+				$include_total_count,
+				$after_cursor,
+				$before_cursor,
+				$per_page
+			)
+		);
+	}
 
 	/**
-     * Get legacy landing pages.
-     *
-     * @param boolean $include_total_count To include the total count of records in the response, use true.
-     * @param string  $after_cursor        Return results after the given pagination cursor.
-     * @param string  $before_cursor       Return results before the given pagination cursor.
-     * @param integer $per_page            Number of results to return.
-     *
-     * @since 2.0.0
-     *
-     * @return WP_Error|array
-     */
-    public function get_legacy_landing_pages(
-        bool $include_total_count = false,
-        string $after_cursor = '',
-        string $before_cursor = '',
-        int $per_page = 100
-    ) {
-    	return $this->get(
-            'landing_pages',
-            $this->build_total_count_and_pagination_params(
-                [
-                    'type'   => 'hosted',
-                ],
-                $include_total_count,
-                $after_cursor,
-                $before_cursor,
-                $per_page
-            )
-        );
-    }
+	 * Get legacy landing pages.
+	 *
+	 * @param boolean $include_total_count To include the total count of records in the response, use true.
+	 * @param string  $after_cursor        Return results after the given pagination cursor.
+	 * @param string  $before_cursor       Return results before the given pagination cursor.
+	 * @param integer $per_page            Number of results to return.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @return WP_Error|array
+	 */
+	public function get_legacy_landing_pages(
+		bool $include_total_count = false,
+		string $after_cursor = '',
+		string $before_cursor = '',
+		int $per_page = 100
+	) {
+		return $this->get(
+			'landing_pages',
+			$this->build_total_count_and_pagination_params(
+				array(
+					'type' => 'hosted',
+				),
+				$include_total_count,
+				$after_cursor,
+				$before_cursor,
+				$per_page
+			)
+		);
+	}
 
 	/**
 	 * Gets posts from the API.

--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -651,6 +651,70 @@ class ConvertKit_API {
 	}
 
 	/**
+     * Get legacy forms.
+     *
+     * @param boolean $include_total_count To include the total count of records in the response, use true.
+     * @param string  $after_cursor        Return results after the given pagination cursor.
+     * @param string  $before_cursor       Return results before the given pagination cursor.
+     * @param integer $per_page            Number of results to return.
+     *
+     * @since 2.0.0
+     *
+     * @return WP_Error|array
+     */
+    public function get_legacy_forms(
+        bool $include_total_count = false,
+        string $after_cursor = '',
+        string $before_cursor = '',
+        int $per_page = 100
+    ) {
+        return $this->get(
+            'landing_pages',
+            $this->build_total_count_and_pagination_params(
+                [
+                    'type'   => 'embed',
+                ],
+                $include_total_count,
+                $after_cursor,
+                $before_cursor,
+                $per_page
+            )
+        );
+    }
+
+	/**
+     * Get legacy landing pages.
+     *
+     * @param boolean $include_total_count To include the total count of records in the response, use true.
+     * @param string  $after_cursor        Return results after the given pagination cursor.
+     * @param string  $before_cursor       Return results before the given pagination cursor.
+     * @param integer $per_page            Number of results to return.
+     *
+     * @since 2.0.0
+     *
+     * @return WP_Error|array
+     */
+    public function get_legacy_landing_pages(
+        bool $include_total_count = false,
+        string $after_cursor = '',
+        string $before_cursor = '',
+        int $per_page = 100
+    ) {
+    	return $this->get(
+            'landing_pages',
+            $this->build_total_count_and_pagination_params(
+                [
+                    'type'   => 'hosted',
+                ],
+                $include_total_count,
+                $after_cursor,
+                $before_cursor,
+                $per_page
+            )
+        );
+    }
+
+	/**
 	 * Gets posts from the API.
 	 *
 	 * @since   1.0.0

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -845,6 +845,56 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
+	 * Test that get_legacy_forms() returns the expected data.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetLegacyForms()
+	{
+		$result = $this->api->get_legacy_forms();
+
+		// Assert forms and pagination exist.
+		$this->assertDataExists($result, 'legacy_landing_pages');
+		$this->assertPaginationExists($result);
+
+		// Iterate through each form, confirming no landing pages were included.
+		foreach ($result['legacy_landing_pages'] as $form) {
+			// Assert shape of object is valid.
+			$this->assertArrayHasKey('id', $form);
+			$this->assertArrayHasKey('name', $form);
+			$this->assertArrayHasKey('created_at', $form);
+			$this->assertArrayHasKey('type', $form);
+			$this->assertArrayHasKey('url', $form);
+
+			// Assert form is not a landing page i.e it is an embed.
+			$this->assertEquals($form['type'], 'embed');
+		}
+	}
+
+	/**
+	 * Test that get_legacy_forms() returns the expected data
+	 * when the total count is included.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetLegacyFormsWithTotalCount()
+	{
+		$result = $this->api->get_forms(true);
+
+		// Assert forms and pagination exist.
+		$this->assertDataExists($result, 'legacy_landing_pages');
+		$this->assertPaginationExists($result);
+
+		// Assert total count is included.
+		$this->assertArrayHasKey('total_count', $result['pagination']);
+		$this->assertGreaterThan(0, $result['pagination']['total_count']);
+	}
+
+	/**
 	 * Test that get_landing_pages() returns the expected data.
 	 *
 	 * @since   1.0.0
@@ -971,6 +1021,56 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		// Assert has_previous_page and has_next_page are correct.
 		$this->assertFalse($result['pagination']['has_previous_page']);
 		$this->assertTrue($result['pagination']['has_next_page']);
+	}
+
+	/**
+	 * Test that get_legacy_landing_pages() returns the expected data.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetLegacyLandingPages()
+	{
+		$result = $this->api->get_legacy_landing_pages();
+
+		// Assert landing pages and pagination exist.
+		$this->assertDataExists($result, 'legacy_landing_pages');
+		$this->assertPaginationExists($result);
+
+		// Iterate through each landing page, confirming no forms were included.
+		foreach ($result['legacy_landing_pages'] as $form) {
+			// Assert shape of object is valid.
+			$this->assertArrayHasKey('id', $form);
+			$this->assertArrayHasKey('name', $form);
+			$this->assertArrayHasKey('created_at', $form);
+			$this->assertArrayHasKey('type', $form);
+			$this->assertArrayHasKey('url', $form);
+
+			// Assert landing page is not a form i.e it is hosted.
+			$this->assertEquals($form['type'], 'hosted');
+		}
+	}
+
+	/**
+	 * Test that get_landing_pages() returns the expected data
+	 * when the total count is included.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetLandingPagesWithTotalCount()
+	{
+		$result = $this->api->get_legacy_landing_pages(true);
+
+		// Assert forms and pagination exist.
+		$this->assertDataExists($result, 'legacy_landing_pages');
+		$this->assertPaginationExists($result);
+
+		// Assert total count is included.
+		$this->assertArrayHasKey('total_count', $result['pagination']);
+		$this->assertGreaterThan(0, $result['pagination']['total_count']);
 	}
 
 	/**

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -883,7 +883,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testGetLegacyFormsWithTotalCount()
 	{
-		$result = $this->api->get_forms(true);
+		$result = $this->api->get_legacy_forms(true);
 
 		// Assert forms and pagination exist.
 		$this->assertDataExists($result, 'legacy_landing_pages');
@@ -1060,7 +1060,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 *
 	 * @return void
 	 */
-	public function testGetLandingPagesWithTotalCount()
+	public function testGetLegacyLandingPagesWithTotalCount()
 	{
 		$result = $this->api->get_legacy_landing_pages(true);
 


### PR DESCRIPTION
## Summary

Adds support for the `v4/landing_pages` endpoint with methods for `get_legacy_forms` and `get_legacy_landing_pages`.

## Testing

- `testGetLegacyForms`: Test that get_legacy_forms() returns the expected data.
- `testGetLegacyFormsWithTotalCount`: Test that get_legacy_forms() returns the expected data when the total count is included.
- `testGetLegacyLandingPages`: Test that get_legacy_landing_pages() returns the expected data.
- `testGetLegacyLandingPagesWithTotalCount`: Test that get_landing_pages() returns the expected data when the total count is included.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)