### PR TITLE
v4 API: Support `state` parameter in OAuth flow

### DIFF
--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -321,24 +321,33 @@ class ConvertKit_API {
 	 * Returns the URL used to begin the OAuth process
 	 *
 	 * @since   2.0.0
-	 *
+	 * 
+	 * @param 	bool|string 	$state 	Optional state parameter to include in OAuth request.
 	 * @return  string                  OAuth URL
 	 */
-	public function get_oauth_url() {
+	public function get_oauth_url( $state = false ) {
 
 		// Generate and store code verifier and challenge.
 		$code_verifier  = $this->generate_and_store_code_verifier();
 		$code_challenge = $this->generate_code_challenge( $code_verifier );
 
+		// Build args.
+		$args = array(
+			'client_id'             => $this->client_id,
+			'response_type'         => 'code',
+			'redirect_uri'          => rawurlencode( $this->redirect_uri ),
+			'code_challenge'        => $code_challenge,
+			'code_challenge_method' => 'S256',
+		);
+
+		// If a state parameter needs to be included, add it now.
+		if ( $state ) {
+			$args['state'] = rawurlencode( $state );
+		}
+
 		// Return OAuth URL.
 		return add_query_arg(
-			array(
-				'client_id'             => $this->client_id,
-				'response_type'         => 'code',
-				'redirect_uri'          => rawurlencode( $this->redirect_uri ),
-				'code_challenge'        => $code_challenge,
-				'code_challenge_method' => 'S256',
-			),
+			$args,
 			$this->oauth_authorize_url
 		);
 

--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -321,8 +321,8 @@ class ConvertKit_API {
 	 * Returns the URL used to begin the OAuth process
 	 *
 	 * @since   2.0.0
-	 * 
-	 * @param 	bool|string 	$state 	Optional state parameter to include in OAuth request.
+	 *
+	 * @param   bool|string $state  Optional state parameter to include in OAuth request.
 	 * @return  string                  OAuth URL
 	 */
 	public function get_oauth_url( $state = false ) {

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -340,6 +340,32 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
+	 * Test that get_oauth_url() returns the correct URL to begin the OAuth process
+	 * when a state parameter is supplied.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return  void
+	 */
+	public function testGetOAuthURLWithState()
+	{
+		// Confirm the OAuth URL returned is correct.
+		$this->assertEquals(
+			$this->api->get_oauth_url( 'an-example-state' ),
+			'https://app.convertkit.com/oauth/authorize?' . http_build_query(
+				[
+					'client_id'             => $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
+					'response_type'         => 'code',
+					'redirect_uri'          => $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
+					'code_challenge'        => $this->api->generate_code_challenge( $this->api->get_code_verifier() ),
+					'code_challenge_method' => 'S256',
+					'state'                 => 'an-example-state',
+				]
+			)
+		);
+	}
+
+	/**
 	 * Test that get_access_token() returns the expected data.
 	 *
 	 * @since   2.0.0


### PR DESCRIPTION
## Summary

Adds support for optionally specifying a `state` parameter in the OAuth flow.

## Testing

- `testGetOAuthURLWithState`: Test that the returned URL includes the `state` parameter when specified in the call to `get_oauth_url`

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)