### PR TITLE
v4 API: Resources: Include Legacy Forms and Landing Pages

### DIFF
--- a/src/class-convertkit-api.php
+++ b/src/class-convertkit-api.php
@@ -1133,7 +1133,10 @@ class ConvertKit_API {
 	}
 
 	/**
-	 * Get HTML for the given URL.
+	 * Get HTML for the given URL, which will be either a:
+	 * - Legacy Form
+	 * - Legacy Landing Page
+	 * - Landing Page
 	 *
 	 * This isn't specifically an API function, but for now it's best suited here.
 	 *
@@ -1141,7 +1144,7 @@ class ConvertKit_API {
 	 * @param   bool   $body_only   Return HTML between <body> and </body> tags only.
 	 * @return  WP_Error|string
 	 */
-	private function get_html( $url, $body_only = true ) {
+	public function get_html( $url, $body_only = true ) {
 
 		// Get HTML from URL.
 		$result = wp_remote_get(

--- a/tests/wpunit/ResourceTest.php
+++ b/tests/wpunit/ResourceTest.php
@@ -292,6 +292,12 @@ class ResourceTest extends \Codeception\TestCase\WPTestCase
 
 		// Assert array keys are preserved.
 		$this->assertArrayHasKey($_ENV['CONVERTKIT_API_FORM_ID'], $resources);
+
+		// Assert the legacy form is included in the data i.e. refreshing forms
+		// did call both `get_forms` and `get_legacy_forms` methods.
+		$this->assertArrayHasKey($_ENV['CONVERTKIT_API_LEGACY_FORM_ID'], $resources);
+		$this->assertArrayHasKey('embed_url', $resources[ $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] ]);
+		$this->assertEquals('https://api.convertkit.com/api/v3/forms/' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . '.html?api_key=' . $_ENV['CONVERTKIT_API_KEY'], $resources[ $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] ]['embed_url']);
 	}
 
 	/**
@@ -323,7 +329,7 @@ class ResourceTest extends \Codeception\TestCase\WPTestCase
 
 		// Assert order of data is in ascending alphabetical order.
 		$this->assertEquals('Character Encoding', reset($result)[ $this->resource->order_by ]);
-		$this->assertEquals('Landing Page', end($result)[ $this->resource->order_by ]);
+		$this->assertEquals('Legacy Landing Page', end($result)[ $this->resource->order_by ]);
 
 		// Confirm resources stored in WordPress options.
 		$resources = get_option($this->resource->settings_name);
@@ -333,6 +339,12 @@ class ResourceTest extends \Codeception\TestCase\WPTestCase
 
 		// Assert array keys are preserved.
 		$this->assertArrayHasKey($_ENV['CONVERTKIT_API_LANDING_PAGE_ID'], $resources);
+
+		// Assert the legacy landing page is included in the data i.e. refreshing landing pages
+		// did call both `get_landing_pages` and `get_legacy_landing_pages` methods.
+		$this->assertArrayHasKey($_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_ID'], $resources);
+		$this->assertArrayHasKey('url', $resources[ $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_ID'] ]);
+		$this->assertEquals('https://app.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_ID'], $resources[ $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_ID'] ]['url']);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Updates the resource class' method when refreshing Forms and Landing Pages to include legacy items.

Makes `get_html` a public method, so that the main ConvertKit Plugin can fetch a legacy form using the `embed_url` property, as this includes the `api_key` required to authenticate and fetch the HTML to output.  As the Plugin is using OAuth, it may not reliably always have a a historical API Key in its settings.

## Testing

- `testRefreshForms`: Updated test to confirm legacy form is included in the resultset, with the required data.
- `testRefreshLandingPages`: Updated test to confirm legacylanding page is included in the resultset, with the required data.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)