### PR TITLE
v4 API: Resources: Exclude Creator Network / Profile Forms

### DIFF
--- a/src/class-convertkit-resource.php
+++ b/src/class-convertkit-resource.php
@@ -649,16 +649,20 @@ class ConvertKit_Resource {
 		// If we're building an array of landing pages, use the appropriate key.
 		switch ( $resource_type ) {
 			case 'landing_pages':
-				$resource_type = 'forms';
+				$type = 'forms';
 				break;
 
 			case 'legacy_forms':
 			case 'legacy_landing_pages':
-				$resource_type = 'legacy_landing_pages';
+				$type = 'legacy_landing_pages';
+				break;
+
+			default:
+				$type = $resource_type;
 				break;
 		}
 
-		foreach ( $response[ $resource_type ] as $item ) {
+		foreach ( $response[ $type ] as $item ) {
 			// Exclude Forms that have a null `format` value, as they are Creator Profile / Creator Network
 			// forms that we don't need in WordPress.
 			// Legacy forms don't have a `format` key, and we always want to include them in the resultset.

--- a/src/class-convertkit-resource.php
+++ b/src/class-convertkit-resource.php
@@ -659,6 +659,13 @@ class ConvertKit_Resource {
 		}
 
 		foreach ( $response[ $resource_type ] as $item ) {
+			// Exclude Forms that have a null `format` value, as they are Creator Profile / Creator Network
+			// forms that we don't need in WordPress.
+			// Legacy forms don't have a `format` key, and we always want to include them in the resultset.
+			if ( $resource_type === 'forms' && array_key_exists( 'format', $item ) && is_null( $item['format'] ) ) {
+				continue;
+			}
+
 			$items[ $item['id'] ] = $item;
 		}
 

--- a/tests/wpunit/ResourceTest.php
+++ b/tests/wpunit/ResourceTest.php
@@ -284,6 +284,16 @@ class ResourceTest extends \Codeception\TestCase\WPTestCase
 		$this->assertEquals('AAA Test', reset($result)[ $this->resource->order_by ]);
 		$this->assertEquals('WooCommerce Product Form', end($result)[ $this->resource->order_by ]);
 
+		// Assert that any Creator Network or Creator Profile form is not included in the resultset.
+		foreach ( $result as $formID => $form) {
+			if ( array_key_exists('format', $form)) {
+				$this->assertNotNull($form['format']);
+			}
+
+			$this->assertNotEquals($form['name'], 'Creator Network');
+			$this->assertNotEquals($form['name'], 'Creator Profile');
+		}
+
 		// Confirm resources stored in WordPress options.
 		$resources = get_option($this->resource->settings_name);
 


### PR DESCRIPTION
## Summary

Depending on the ConvertKit account, the call to the `forms` endpoint might return Creator Network and/or Creator Profile forms:

![Screenshot 2024-05-29 at 11 58 35](https://github.com/ConvertKit/convertkit-wordpress-libraries/assets/1462305/8ce32597-88b7-485c-acbd-24cf6be32109)

![Screenshot 2024-05-29 at 11 58 45](https://github.com/ConvertKit/convertkit-wordpress-libraries/assets/1462305/afe0f21c-67fa-429b-ab49-65ccbcec01b8)

This PR excludes the Creator Network and Creator Profile forms from the resource class, as they don't seem to be embeddable forms that we can use in WordPress right now - so making them a selectable form option doesn't make sense.

The underlying API call to `get_forms` will still return these forms, should there be a specific future use case where we need them in WordPress.

## Testing

- `ResourceTest:testRefreshForms`: Assert that no forms are returned where a `format` key exists that is `null` i.e. a Creator Network / Profile form.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)