### PR TITLE
v4 API: Update Class Names

### DIFF
--- a/src/class-convertkit-api-v4.php
+++ b/src/class-convertkit-api-v4.php
@@ -12,7 +12,7 @@
  * @package ConvertKit
  * @author ConvertKit
  */
-class ConvertKit_API {
+class ConvertKit_API_V4 {
 
 	use ConvertKit_API_Traits;
 

--- a/src/class-convertkit-resource-v4.php
+++ b/src/class-convertkit-resource-v4.php
@@ -12,7 +12,7 @@
  *
  * @since   1.0.0
  */
-class ConvertKit_Resource {
+class ConvertKit_Resource_V4 {
 
 	/**
 	 * Holds the key that stores the resources in the option database table.

--- a/src/class-convertkit-resource.php
+++ b/src/class-convertkit-resource.php
@@ -31,7 +31,7 @@ class ConvertKit_Resource {
 	/**
 	 * The API class
 	 *
-	 * @var     bool|ConvertKit_API
+	 * @var     bool|ConvertKit_API_V4
 	 */
 	public $api = false;
 

--- a/tests/wpunit/APINoDataTest.php
+++ b/tests/wpunit/APINoDataTest.php
@@ -43,11 +43,11 @@ class APINoDataTest extends \Codeception\TestCase\WPTestCase
 
 		// Include class from /src to test.
 		require_once 'src/class-convertkit-api-traits.php';
-		require_once 'src/class-convertkit-api.php';
+		require_once 'src/class-convertkit-api-v4.php';
 		require_once 'src/class-convertkit-log.php';
 
 		// Initialize the classes we want to test.
-		$this->api = new ConvertKit_API(
+		$this->api = new ConvertKit_API_V4(
 			$_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
 			$_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
 			$_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN_NO_DATA'],

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -3889,6 +3889,9 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testUnsubscribeByEmail()
 	{
+		// Avoid a rate limit due to previous tests.
+		sleep(2);
+
 		// Add a subscriber.
 		$emailAddress = $this->generateEmailAddress();
 		$result       = $this->api->create_subscriber(

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -78,18 +78,18 @@ class APITest extends \Codeception\TestCase\WPTestCase
 
 		// Include class from /src to test.
 		require_once 'src/class-convertkit-api-traits.php';
-		require_once 'src/class-convertkit-api.php';
+		require_once 'src/class-convertkit-api-v4.php';
 		require_once 'src/class-convertkit-log.php';
 
 		// Initialize the classes we want to test.
-		$this->api = new ConvertKit_API(
+		$this->api = new ConvertKit_API_V4(
 			$_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
 			$_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
 			$_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
 			$_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN']
 		);
 
-		$this->api_no_data = new ConvertKit_API(
+		$this->api_no_data = new ConvertKit_API_V4(
 			$_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
 			$_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
 			$_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN_NO_DATA'],
@@ -142,7 +142,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$this->tester->writeToFile(CONVERTKIT_PLUGIN_PATH . '/log.txt', 'historical log file');
 
 		// Initialize API with logging enabled.
-		$api = new ConvertKit_API(
+		$api = new ConvertKit_API_V4(
 			$_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
 			$_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
 			$_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
@@ -190,7 +190,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function test401Unauthorized()
 	{
-		$api    = new ConvertKit_API(
+		$api    = new ConvertKit_API_V4(
 			$_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
 			$_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
 			'not-a-real-access-token',
@@ -281,7 +281,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		);
 
 		// Perform a request.
-		$api    = new ConvertKit_API(
+		$api    = new ConvertKit_API_V4(
 			$_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
 			$_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
 			$_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
@@ -472,7 +472,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	public function testRefreshTokenWithInvalidToken()
 	{
 		// Setup API.
-		$api = new ConvertKit_API(
+		$api = new ConvertKit_API_V4(
 			$_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
 			$_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
 			$_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
@@ -491,7 +491,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testInvalidAPICredentials()
 	{
-		$api    = new ConvertKit_API( $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'], $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'] );
+		$api    = new ConvertKit_API_V4( $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'], $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'] );
 		$result = $api->get_account();
 		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);
@@ -505,7 +505,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testGetAccessTokenByAPIKeyAndSecret()
 	{
-		$api    = new ConvertKit_API( $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'], $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'] );
+		$api    = new ConvertKit_API_V4( $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'], $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'] );
 		$result = $api->get_access_token_by_api_key_and_secret(
 			$_ENV['CONVERTKIT_API_KEY'],
 			$_ENV['CONVERTKIT_API_SECRET']
@@ -525,7 +525,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	 */
 	public function testGetAccessTokenByInvalidAPIKeyAndSecret()
 	{
-		$api    = new ConvertKit_API( $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'], $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'] );
+		$api    = new ConvertKit_API_V4( $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'], $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'] );
 		$result = $api->get_access_token_by_api_key_and_secret(
 			'invalid-api-key',
 			'invalid-api-secret'

--- a/tests/wpunit/ResourceTest.php
+++ b/tests/wpunit/ResourceTest.php
@@ -34,10 +34,10 @@ class ResourceTest extends \Codeception\TestCase\WPTestCase
 		// Include class from /src to test.
 		require_once 'src/class-convertkit-api-traits.php';
 		require_once 'src/class-convertkit-api-v4.php';
-		require_once 'src/class-convertkit-resource.php';
+		require_once 'src/class-convertkit-resource-v4.php';
 
 		// Initialize the classes we want to test.
-		$this->resource = new ConvertKit_Resource();
+		$this->resource = new ConvertKit_Resource_V4();
 	}
 
 	/**

--- a/tests/wpunit/ResourceTest.php
+++ b/tests/wpunit/ResourceTest.php
@@ -33,7 +33,7 @@ class ResourceTest extends \Codeception\TestCase\WPTestCase
 
 		// Include class from /src to test.
 		require_once 'src/class-convertkit-api-traits.php';
-		require_once 'src/class-convertkit-api.php';
+		require_once 'src/class-convertkit-api-v4.php';
 		require_once 'src/class-convertkit-resource.php';
 
 		// Initialize the classes we want to test.
@@ -264,7 +264,7 @@ class ResourceTest extends \Codeception\TestCase\WPTestCase
 		// Assign resource type and API.
 		$this->resource->settings_name = 'convertkit_resource_forms';
 		$this->resource->type          = 'forms';
-		$this->resource->api           = new ConvertKit_API(
+		$this->resource->api           = new ConvertKit_API_V4(
 			$_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
 			$_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
 			$_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
@@ -311,7 +311,7 @@ class ResourceTest extends \Codeception\TestCase\WPTestCase
 		// Assign resource type and API.
 		$this->resource->settings_name = 'convertkit_resource_landing_pages';
 		$this->resource->type          = 'landing_pages';
-		$this->resource->api           = new ConvertKit_API(
+		$this->resource->api           = new ConvertKit_API_V4(
 			$_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
 			$_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
 			$_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
@@ -358,7 +358,7 @@ class ResourceTest extends \Codeception\TestCase\WPTestCase
 		// Assign resource type and API.
 		$this->resource->settings_name = 'convertkit_resource_tags';
 		$this->resource->type          = 'tags';
-		$this->resource->api           = new ConvertKit_API(
+		$this->resource->api           = new ConvertKit_API_V4(
 			$_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
 			$_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
 			$_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
@@ -400,7 +400,7 @@ class ResourceTest extends \Codeception\TestCase\WPTestCase
 		$this->resource->settings_name = 'convertkit_resource_custom_fields';
 		$this->resource->type          = 'custom_fields';
 		$this->resource->order_by      = 'label';
-		$this->resource->api           = new ConvertKit_API(
+		$this->resource->api           = new ConvertKit_API_V4(
 			$_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
 			$_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
 			$_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
@@ -441,7 +441,7 @@ class ResourceTest extends \Codeception\TestCase\WPTestCase
 		// Assign resource type and API.
 		$this->resource->settings_name = 'convertkit_resource_sequences';
 		$this->resource->type          = 'sequences';
-		$this->resource->api           = new ConvertKit_API(
+		$this->resource->api           = new ConvertKit_API_V4(
 			$_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
 			$_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
 			$_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
@@ -482,7 +482,7 @@ class ResourceTest extends \Codeception\TestCase\WPTestCase
 		// Assign resource type and API.
 		$this->resource->settings_name = 'convertkit_resource_products';
 		$this->resource->type          = 'products';
-		$this->resource->api           = new ConvertKit_API(
+		$this->resource->api           = new ConvertKit_API_V4(
 			$_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
 			$_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
 			$_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
@@ -525,7 +525,7 @@ class ResourceTest extends \Codeception\TestCase\WPTestCase
 		$this->resource->type          = 'posts';
 		$this->resource->order_by      = 'published_at';
 		$this->resource->order         = 'desc';
-		$this->resource->api           = new ConvertKit_API(
+		$this->resource->api           = new ConvertKit_API_V4(
 			$_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
 			$_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
 			$_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
@@ -565,7 +565,7 @@ class ResourceTest extends \Codeception\TestCase\WPTestCase
 	{
 		// Assign resource type and API.
 		$this->resource->type = 'not-a-valid-resource-type';
-		$this->resource->api  = new ConvertKit_API(
+		$this->resource->api  = new ConvertKit_API_V4(
 			$_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
 			$_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
 			$_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],


### PR DESCRIPTION
## Summary

Renames `ConvertKit_API` to `ConvertKit_API_V4` and `ConvertKit_Resources` to `ConvertKit_Resources_V4`, to prevent [this conflict](https://github.com/ConvertKit/convertkit-wordpress/pull/671) when running multiple ConvertKit Plugins that might use different versions of the API.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)