### PR TITLE
v4 API: Add Subscriber to Legacy Forms / Landing Pages

### DIFF
--- a/src/class-convertkit-api-traits.php
+++ b/src/class-convertkit-api-traits.php
@@ -256,6 +256,21 @@ trait ConvertKit_API_Traits
     }
 
     /**
+     * Adds a subscriber to a legacy form by subscriber ID
+     *
+     * @param integer $form_id       Legacy Form ID.
+     * @param integer $subscriber_id Subscriber ID.
+     *
+     * @since 2.0.0
+     *
+     * @return WP_Error|array
+     */
+    public function add_subscriber_to_legacy_form(int $form_id, int $subscriber_id)
+    {
+        return $this->post(sprintf('landing_pages/%s/subscribers/%s', $form_id, $subscriber_id));
+    }
+
+    /**
      * List subscribers for a form
      *
      * @param integer   $form_id             Form ID.

--- a/src/class-convertkit-api-v4.php
+++ b/src/class-convertkit-api-v4.php
@@ -490,6 +490,32 @@ class ConvertKit_API_V4 {
 	}
 
 	/**
+	 * Creates the given subscriber, assiging them to the given ConvertKit Legacy Form.
+	 *
+	 * @since  2.0.0
+	 *
+	 * @param   int    $form_id        Form ID.
+	 * @param   string $email          Email Address.
+	 * @param   string $first_name     First Name.
+	 * @param   array  $custom_fields  Custom Fields.
+	 * @return  WP_Error|array
+	 */
+	public function legacy_form_subscribe( $form_id, $email, $first_name = '', $custom_fields = array() ) {
+
+		// Create subscriber.
+		$subscriber = $this->create_subscriber( $email, $first_name, 'active', $custom_fields );
+
+		// Bail if an error occured.
+		if ( is_wp_error( $subscriber ) ) {
+			return $subscriber;
+		}
+
+		// Add subscriber to legacy form.
+		return $this->add_subscriber_to_legacy_form( $form_id, $subscriber['subscriber']['id'] );
+
+	}
+
+	/**
 	 * Creates the given subscriber, assiging them to the given ConvertKit Tag.
 	 *
 	 * @since  1.0.0

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -1547,6 +1547,24 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
+	 * Test that add_subscriber_to_form() returns a WP_Error when a legacy
+	 * form ID is specified.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testAddSubscriberToFormWithLegacyFormID()
+	{
+		$result = $this->api->add_subscriber_to_form(
+			$_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
+			$_ENV['CONVERTKIT_API_SUBSCRIBER_ID']
+		);
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+	}
+
+	/**
 	 * Test that add_subscriber_to_form() returns a WP_Error when an invalid
 	 * email address is specified.
 	 *
@@ -1558,6 +1576,92 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	{
 		$result = $this->api->add_subscriber_to_form(
 			$_ENV['CONVERTKIT_API_FORM_ID'],
+			12345
+		);
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+	}
+
+	/**
+	 * Test that add_subscriber_to_legacy_form() returns the expected data.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testAddSubscriberToLegacyForm()
+	{
+		// Create subscriber.
+		$subscriber = $this->api->create_subscriber(
+			$this->generateEmailAddress()
+		);
+
+		$this->assertNotInstanceOf(WP_Error::class, $subscriber);
+		$this->assertIsArray($subscriber);
+
+		// Set subscriber_id to ensure subscriber is unsubscribed after test.
+		$this->subscriber_ids[] = $subscriber['subscriber']['id'];
+
+		// Add subscriber to legacy form.
+		$result = $this->api->add_subscriber_to_legacy_form(
+			(int) $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
+			$subscriber['subscriber']['id']
+		);
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('subscriber', $result);
+		$this->assertArrayHasKey('id', $result['subscriber']);
+		$this->assertEquals($result['subscriber']['id'], $subscriber['subscriber']['id']);
+	}
+
+	/**
+	 * Test that add_subscriber_to_legacy_form() returns a WP_Error when an invalid
+	 * form ID is specified.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testAddSubscriberToLegacyFormWithInvalidFormID()
+	{
+		$result = $this->api->add_subscriber_to_legacy_form(
+			12345,
+			$_ENV['CONVERTKIT_API_SUBSCRIBER_ID']
+		);
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+	}
+
+	/**
+	 * Test that add_subscriber_to_legacy_form() returns a WP_Error when a non-legacy
+	 * form ID is specified.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testAddSubscriberToLegacyFormWithNonLegacyFormID()
+	{
+		$result = $this->api->add_subscriber_to_legacy_form(
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['CONVERTKIT_API_SUBSCRIBER_ID']
+		);
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+	}
+
+	/**
+	 * Test that add_subscriber_to_legacy_form() returns a WP_Error when an invalid
+	 * email address is specified.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testAddSubscriberToLegacyFormWithInvalidSubscriberID()
+	{
+		$result = $this->api->add_subscriber_to_legacy_form(
+			$_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
 			12345
 		);
 		$this->assertInstanceOf(WP_Error::class, $result);
@@ -4916,6 +5020,24 @@ class APITest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the `form_subscribe()` function returns a WP_Error
+	 * when a legacy Form ID is specified.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testFormSubscribeWithLegacyFormID()
+	{
+		$result = $this->api->form_subscribe(
+			$_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
+			$this->generateEmailAddress()
+		);
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+	}
+
+	/**
+	 * Test that the `form_subscribe()` function returns a WP_Error
 	 * when an invalid email address is specified.
 	 *
 	 * @since   2.0.0
@@ -4926,6 +5048,90 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	{
 		$result = $this->api->form_subscribe(
 			$_ENV['CONVERTKIT_API_FORM_ID'],
+			'not-a-valid-email'
+		);
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+	}
+
+	/**
+	 * Test that the `legacy_form_subscribe()` function returns the expected data.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testLegacyFormSubscribe()
+	{
+		// Make request.
+		$emailAddress = $this->generateEmailAddress();
+		$result       = $this->api->legacy_form_subscribe(
+			$_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
+			$emailAddress,
+			'First',
+			[
+				'last_name' => 'Last',
+			]
+		);
+
+		// Test array was returned.
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+
+		// Assert subscriber created.
+		$this->assertArrayHasKey('subscriber', $result);
+		$this->assertArrayHasKey('email_address', $result['subscriber']);
+		$this->assertEquals($emailAddress, $result['subscriber']['email_address']);
+	}
+
+	/**
+	 * Test that the `legacy_form_subscribe()` function returns a WP_Error
+	 * when an invalid Form ID is specified.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testLegacyFormSubscribeWithInvalidFormID()
+	{
+		$result = $this->api->legacy_form_subscribe(
+			12345,
+			$this->generateEmailAddress()
+		);
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+	}
+
+	/**
+	 * Test that the `legacy_form_subscribe()` function returns a WP_Error
+	 * when a non-legacy Form ID is specified.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testLegacyFormSubscribeWithNonLegacyFormID()
+	{
+		$result = $this->api->legacy_form_subscribe(
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$this->generateEmailAddress()
+		);
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+	}
+
+	/**
+	 * Test that the `legacy_form_subscribe()` function returns a WP_Error
+	 * when an invalid email address is specified.
+	 *
+	 * @since   2.0.0
+	 *
+	 * @return void
+	 */
+	public function testLegacyFormSubscribeWithInvalidEmailAddress()
+	{
+		$result = $this->api->legacy_form_subscribe(
+			$_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
 			'not-a-valid-email'
 		);
 		$this->assertInstanceOf(WP_Error::class, $result);


### PR DESCRIPTION
## Summary

Adds methods to add a subscriber to a legacy Form / Landing Page.

These are [undocumented v4 API methods](https://github.com/ConvertKit/convertkit/pull/29152), but we need them for existing Plugin installations that are configured to add subscribers to Legacy Forms / Landing Pages (such as our WooCommerce integration).

## Testing

- Test coverage added for testing new methods

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)