### PR TITLE
v4 API: Add existing Access and Refresh Tokens to the `convertkit_api_refresh_token` action

### DIFF
--- a/src/class-convertkit-api-v4.php
+++ b/src/class-convertkit-api-v4.php
@@ -392,7 +392,7 @@ class ConvertKit_API_V4 {
 		 * @since   2.0.0
 		 *
 		 * @param   array   $result     Access Token, Refresh Token, Expiry, Bearer and Scope.
-		 * @param   string  $client_id  OAUth Client ID.
+		 * @param   string  $client_id  OAuth Client ID.
 		 */
 		do_action( 'convertkit_api_get_access_token', $result, $this->client_id );
 
@@ -432,10 +432,12 @@ class ConvertKit_API_V4 {
 		 *
 		 * @since   2.0.0
 		 *
-		 * @param   array   $result     Access Token, Refresh Token, Expiry, Bearer and Scope.
-		 * @param   string  $client_id  OAUth Client ID.
+		 * @param   array   $result         New Access Token, Refresh Token, Expiry, Bearer and Scope.
+		 * @param   string  $client_id      OAuth Client ID.
+		 * @param   string  $access_token   Existing Access Token.
+		 * @param   string  $refresh_token  Existing Refresh Token.
 		 */
-		do_action( 'convertkit_api_refresh_token', $result, $this->client_id );
+		do_action( 'convertkit_api_refresh_token', $result, $this->client_id, $this->access_token, $this->refresh_token );
 
 		// Return.
 		return $result;

--- a/src/class-convertkit-api-v4.php
+++ b/src/class-convertkit-api-v4.php
@@ -423,6 +423,10 @@ class ConvertKit_API_V4 {
 			return $result;
 		}
 
+		// Store existing access and refresh tokens.
+		$previous_access_token  = $this->access_token;
+		$previous_refresh_token = $this->refresh_token;
+
 		// Update the access and refresh tokens in this class.
 		$this->access_token  = $result['access_token'];
 		$this->refresh_token = $result['refresh_token'];
@@ -432,12 +436,12 @@ class ConvertKit_API_V4 {
 		 *
 		 * @since   2.0.0
 		 *
-		 * @param   array   $result         New Access Token, Refresh Token, Expiry, Bearer and Scope.
-		 * @param   string  $client_id      OAuth Client ID.
-		 * @param   string  $access_token   Existing Access Token.
-		 * @param   string  $refresh_token  Existing Refresh Token.
+		 * @param   array   $result                  New Access Token, Refresh Token, Expiry, Bearer and Scope.
+		 * @param   string  $client_id               OAuth Client ID.
+		 * @param   string  $previous_access_token   Existing Access Token.
+		 * @param   string  $previous_refresh_token  Existing Refresh Token.
 		 */
-		do_action( 'convertkit_api_refresh_token', $result, $this->client_id, $this->access_token, $this->refresh_token );
+		do_action( 'convertkit_api_refresh_token', $result, $this->client_id, $previous_access_token, $previous_refresh_token );
 
 		// Return.
 		return $result;


### PR DESCRIPTION
## Summary

Adds the existing Access and Refresh Tokens to the `convertkit_api_refresh_token` action.

This allows Plugins that hook to this action to determine which existing Access / Refresh Token combination has been updated.  For example, our [WPForms Plugin supports multiple connections](https://github.com/ConvertKit/convertkit-wpforms/pull/51) / accounts to ConvertKit, and therefore will need this functionality to know which Access / Refresh Token pair to update in the Plugin’s settings.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)