### PR TITLE
v4 API: Encode `state` parameter

### DIFF
--- a/src/class-convertkit-api-v4.php
+++ b/src/class-convertkit-api-v4.php
@@ -319,7 +319,7 @@ class ConvertKit_API_V4 {
 	 * @param   string $str    String to encode.
 	 * @return                  Encoded string.
 	 */
-	private function base64_urlencode( $str ) {
+	public function base64_urlencode( $str ) {
 
 		// Encode to Base64 string.
 		$str = base64_encode( $str ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions
@@ -339,10 +339,10 @@ class ConvertKit_API_V4 {
 	 *
 	 * @since   2.0.0
 	 *
-	 * @param   string $state  State.
-	 * @return  string         OAuth URL
+	 * @param   string $return_url  Return URL.
+	 * @return  string              OAuth URL
 	 */
-	public function get_oauth_url( $state = false ) {
+	public function get_oauth_url( $return_url = false ) {
 
 		// Generate and store code verifier and challenge.
 		$code_verifier  = $this->generate_and_store_code_verifier();
@@ -357,11 +357,11 @@ class ConvertKit_API_V4 {
 			'code_challenge_method' => 'S256',
 		);
 
-		if ( $state ) {
+		if ( $return_url ) {
 			$args['state'] = $this->base64_urlencode(
 				wp_json_encode(
 					array(
-						'return_to' => $state,
+						'return_to' => $return_url,
 						'client_id' => $this->client_id,
 					)
 				)

--- a/src/class-convertkit-api-v4.php
+++ b/src/class-convertkit-api-v4.php
@@ -339,8 +339,8 @@ class ConvertKit_API_V4 {
 	 *
 	 * @since   2.0.0
 	 *
-	 * @param   string $return_url  Return URL.
-	 * @return  string              OAuth URL
+	 * @param   bool|string $return_url  Return URL.
+	 * @return  string                       OAuth URL
 	 */
 	public function get_oauth_url( $return_url = false ) {
 

--- a/src/class-convertkit-api-v4.php
+++ b/src/class-convertkit-api-v4.php
@@ -317,7 +317,7 @@ class ConvertKit_API_V4 {
 	 * @since   2.0.0
 	 *
 	 * @param   string $str    String to encode.
-	 * @return                  Encoded string.
+	 * @return  string         Encoded string.
 	 */
 	public function base64_urlencode( $str ) {
 

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -351,7 +351,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	{
 		// Confirm the OAuth URL returned is correct.
 		$this->assertEquals(
-			$this->api->get_oauth_url( 'an-example-state' ),
+			$this->api->get_oauth_url( 'https://example.com' ),
 			'https://app.convertkit.com/oauth/authorize?' . http_build_query(
 				[
 					'client_id'             => $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
@@ -359,7 +359,14 @@ class APITest extends \Codeception\TestCase\WPTestCase
 					'redirect_uri'          => $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
 					'code_challenge'        => $this->api->generate_code_challenge( $this->api->get_code_verifier() ),
 					'code_challenge_method' => 'S256',
-					'state'                 => 'an-example-state',
+					'state'                 => $this->api->base64_urlencode(
+						wp_json_encode(
+							array(
+								'return_to' => 'https://example.com',
+								'client_id' => $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
+							)
+						)
+					),
 				]
 			)
 		);


### PR DESCRIPTION
## Summary

Base64URL encodes the `state` parameter with the necessary `return_to` and `client_id` data required for the [ConvertKit hosted universal redirect URL](https://github.com/ConvertKit/convertkit/pull/29208).

## Testing

- `testGetOAuthURLWithState`: Updated test to assert `state` parameter contains the correct data.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)