### PR TITLE
Conditionally append parameters to `GET` requests

### DIFF
--- a/src/class-convertkit-api-v4.php
+++ b/src/class-convertkit-api-v4.php
@@ -1325,12 +1325,19 @@ class ConvertKit_API_V4 {
 		// Send request.
 		switch ( strtolower( $method ) ) {
 			case 'get':
+				// Build URL.
+				$url = $this->get_api_url( $endpoint );
+
 				// We deliberate don't use add_query_arg(), as this converts double equal signs (typically
 				// provided by `start_cursor` and `end_cursor`) to a single equal sign, therefore breaking
 				// pagination.  http_build_query() will encode equals signs instead, preserving them
 				// and ensuring paginated requests work correctly.
+				if ( count( $params ) ) {
+					$url .= '?' . http_build_query( $params );
+				}
+
 				$result = wp_remote_get(
-					$this->get_api_url( $endpoint ) . '?' . http_build_query( $params ),
+					$url,
 					array(
 						'headers'    => $this->get_request_headers(),
 						'timeout'    => $this->get_timeout(),


### PR DESCRIPTION
## Summary

Conditionally appends parameters to `GET` requests, as some requests with no parameters resulted in `?` being appended and a redirect being performed as part of the API request:

<img width="370" alt="Screenshot 2024-07-10 at 16 15 56" src="https://github.com/ConvertKit/convertkit-wordpress-libraries/assets/1462305/3ac42569-f8c6-40a7-a0bb-b7c71ab78e1c">

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)