### PR TITLE
Remove `rocket-loader.min.js` from Landing Pages

### DIFF
--- a/src/class-convertkit-api-traits.php
+++ b/src/class-convertkit-api-traits.php
@@ -1662,6 +1662,12 @@ trait ConvertKit_API_Traits
                 continue;
             }
 
+            // Remove element if it's rocket-loader.min.js. Including it prevents landing page redirects from working.
+            if (strpos($element->getAttribute($attribute), 'rocket-loader.min.js') !== false) {
+                $element->parentNode->removeChild($element);
+                continue;
+            }
+
             // If here, the attribute's value is a relative URL, missing the http(s) and domain.
             // Prepend the URL to the attribute's value.
             $element->setAttribute($attribute, $url . $element->getAttribute($attribute));

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -6141,6 +6141,9 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$result = $this->api->get_landing_page_html($_ENV['CONVERTKIT_API_LANDING_PAGE_URL']);
 		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertStringContainsString('<form method="POST" action="https://app.convertkit.com/forms/' . $_ENV['CONVERTKIT_API_LANDING_PAGE_ID'] . '/subscriptions" data-sv-form="' . $_ENV['CONVERTKIT_API_LANDING_PAGE_ID'] . '" data-uid="99f1db6843" class="formkit-form"', $result);
+
+		// Check that rocket-loader.min.js has been removed, as including it breaks landing page redirects.
+		$this->assertStringNotContainsString('rocket-loader.min.js', $result);
 	}
 
 	/**
@@ -6157,6 +6160,9 @@ class APITest extends \Codeception\TestCase\WPTestCase
 
 		// Assert that character encoding works, and that special characters are not malformed.
 		$this->assertStringContainsString('Vantar þinn ungling sjálfstraust í stærðfræði?', $result);
+
+		// Check that rocket-loader.min.js has been removed, as including it breaks landing page redirects.
+		$this->assertStringNotContainsString('rocket-loader.min.js', $result);
 	}
 
 	/**
@@ -6170,6 +6176,9 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$result = $this->api->get_landing_page_html($_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_URL']);
 		$this->assertNotInstanceOf(WP_Error::class, $result);
 		$this->assertStringContainsString('<form id="ck_subscribe_form" class="ck_subscribe_form" action="https://app.convertkit.com/landing_pages/' . $_ENV['CONVERTKIT_API_LEGACY_LANDING_PAGE_ID'] . '/subscribe" data-remote="true">', $result);
+
+		// Check that rocket-loader.min.js has been removed, as including it breaks landing page redirects.
+		$this->assertStringNotContainsString('rocket-loader.min.js', $result);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://linear.app/kit/issue/BCDC-3182/bcdc-embedded-landing-pages-on-wordpress-do-not-redirect-when-someone), where a Landing Page setup to redirect, and embedded in WordPress, won't redirect to the thank you page URL.

The redirect not being honored appears to be caused by including `rocket-loader.min.js`.

The Plugin fetches the landing page HTML, and then iterates through all scripts, checking if each src property is a fully qualified URL. If not (e.g. on landing pages, we find `<script src="/cdn-cgi/scripts/7d0fa10a/cloudflare-static/rocket-loader.min.js" data-cf-settings="5756229aeeb7b4c76b79f093-|49" defer></script>`), the Plugin will prepend the creator's URL (e.g. `<script src="https://cheerful-architect-3237.ck.page/cdn-cgi/scripts/7d0fa10a/cloudflare-static/rocket-loader.min.js" data-cf-settings="c5d46ab73fb7b9b8aae27edf-|49" defer></script>`) to ensure it can load the script on a WordPress Page that outputs the landing page HTML (otherwise, the relative path to the script won't work, because the landing page isn't hosted by ConvertKit here).

Removing this script allows the redirect to work, but I'm not understanding why, or whether this script can safely be removed by our WordPress Libraries / Plugins. If someone could let me know, we can then get this fixed.

## Testing

- Updated unit tests to confirm `rocket-loader.min.js` is removed. The main WordPress Plugin will need its own PR to confirm the same when using this version of the WordPress Libraries.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)