### PR TITLE
Tests: Fix Invalid API Credentials

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,7 @@ jobs:
 
     # Defines the WordPress and PHP Versions matrix to run tests on.
     strategy:
+      fail-fast: false
       matrix:
         wp-versions: [ 'latest' ] #[ 'latest', '6.1.1' ]
         php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3' ] #[ '7.4', '8.0', '8.1', '8.2' ]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
     # Defines the WordPress and PHP Versions matrix to run tests on.
     strategy:
       matrix:
-        wp-versions: [ '6.6-RC3' ] #[ 'latest', '6.1.1' ]
+        wp-versions: [ 'latest' ] #[ 'latest', '6.1.1' ]
         php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3' ] #[ '7.4', '8.0', '8.1', '8.2' ]
 
     # Steps to install, configure and run tests

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -492,13 +492,27 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
+	 * Test that supplying no API credentials to the API class returns a WP_Error.
+	 *
+	 * @since   2.0.2
+	 */
+	public function testNoAPICredentials()
+	{
+		$api    = new ConvertKit_API_V4( $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'], $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'] );
+		$result = $api->get_account();
+		$this->assertInstanceOf(WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
+		$this->assertEquals($result->get_error_message(), 'Authentication Failed');
+	}
+
+	/**
 	 * Test that supplying invalid API credentials to the API class returns a WP_Error.
 	 *
 	 * @since   1.0.0
 	 */
 	public function testInvalidAPICredentials()
 	{
-		$api    = new ConvertKit_API_V4( $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'], $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'] );
+		$api    = new ConvertKit_API_V4( $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'], $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'], 'fakeAccessToken', 'fakeRefreshToken' );
 		$result = $api->get_account();
 		$this->assertInstanceOf(WP_Error::class, $result);
 		$this->assertEquals($result->get_error_code(), $this->errorCode);


### PR DESCRIPTION
## Summary

- Runs tests against latest WordPress version
- Fixes `testInvalidAPICredentials` to assert the expected message returned from the API
- Adds `testNoAPICredentials` to assert the expected message is returned from the API

## Testing

Existing tests now pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)