### PR TITLE
Check response in `get_error_message_string` is an array

### DIFF
--- a/src/class-convertkit-api-v4.php
+++ b/src/class-convertkit-api-v4.php
@@ -1540,10 +1540,15 @@ class ConvertKit_API_V4 {
 	 *
 	 * @since   2.0.0
 	 *
-	 * @param   array $response   API Response.
-	 * @return  string              Error Message(s).
+	 * @param   null|array $response   API Response.
+	 * @return  string                  Error Message(s).
 	 */
 	private function get_error_message_string( $response ) {
+
+		// If there is no API response body (such as a 429 error), there'll be no error message to return.
+		if ( ! is_array( $response ) ) {
+			return '';
+		}
 
 		// Most API responses contain the `errors` key.
 		if ( array_key_exists( 'errors', $response ) ) {

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -213,14 +213,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		// Force WordPress HTTP classes and functions to return a 429 error.
 		$this->mockResponses(
 			429,
-			'Rate limit hit',
-			wp_json_encode(
-				array(
-					'errors' => array(
-						'Rate limit hit.',
-					),
-				)
-			)
+			'Rate limit hit'
 		);
 		$result = $this->api->get_account(); // The API function we use doesn't matter, as mockResponse forces a 429 error.
 		$this->assertInstanceOf(WP_Error::class, $result);


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://linear.app/kit/issue/BCDC-3236/bcdc-question-about-a-fatal-error), where a 429 rate limit won't include data in the body.  The WordPress Libraries would wrongly assume a body is always returned when attempting to parse the error message from the body.

## Testing

- `test429RateLimitHit`: This is a mocked test, so removed the body response to confirm no PHP error is triggered.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)