### PR TITLE
Fix Landing Page `html` tag detection

### DIFF
--- a/src/class-convertkit-api-v4.php
+++ b/src/class-convertkit-api-v4.php
@@ -1235,7 +1235,7 @@ class ConvertKit_API_V4 {
 
 		// If the HTML is missing the <html> tag, it's likely to be a legacy form.
 		// Wrap it in <html>, <head> and <body> tags now, so we can inject the UTF-8 Content-Type meta tag.
-		if ( strpos( $body, '<html>' ) === false ) {
+		if ( strpos( $body, '<html' ) === false ) {
 			$body = '<html><head></head><body>' . $body . '</body></html>';
 		}
 

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -6177,6 +6177,11 @@ class APITest extends \Codeception\TestCase\WPTestCase
 
 		// Check that rocket-loader.min.js has been removed, as including it breaks landing page redirects.
 		$this->assertStringNotContainsString('rocket-loader.min.js', $result);
+
+		// Check that the <html> tag wasn't replaced, as this isn't a legacy landing page.
+		// It should be preserved as e.g. <html lang="en">.
+		$this->assertStringContainsString('<html lang="en">');
+		$this->assertStringNotContainsString('<html>');
 	}
 
 	/**
@@ -6196,6 +6201,11 @@ class APITest extends \Codeception\TestCase\WPTestCase
 
 		// Check that rocket-loader.min.js has been removed, as including it breaks landing page redirects.
 		$this->assertStringNotContainsString('rocket-loader.min.js', $result);
+
+		// Check that the <html> tag wasn't replaced, as this isn't a legacy landing page.
+		// It should be preserved as e.g. <html lang="en">.
+		$this->assertStringContainsString('<html lang="en">');
+		$this->assertStringNotContainsString('<html>');
 	}
 
 	/**
@@ -6212,6 +6222,9 @@ class APITest extends \Codeception\TestCase\WPTestCase
 
 		// Check that rocket-loader.min.js has been removed, as including it breaks landing page redirects.
 		$this->assertStringNotContainsString('rocket-loader.min.js', $result);
+
+		// Check that the <html> tag was added, as this isn't included in legacy landing pages.
+		$this->assertStringContainsString('<html>');
 	}
 
 	/**

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -6180,8 +6180,8 @@ class APITest extends \Codeception\TestCase\WPTestCase
 
 		// Check that the <html> tag wasn't replaced, as this isn't a legacy landing page.
 		// It should be preserved as e.g. <html lang="en">.
-		$this->assertStringContainsString('<html lang="en">');
-		$this->assertStringNotContainsString('<html>');
+		$this->assertStringContainsString('<html lang="en">', $result);
+		$this->assertStringNotContainsString('<html>', $result);
 	}
 
 	/**
@@ -6201,11 +6201,6 @@ class APITest extends \Codeception\TestCase\WPTestCase
 
 		// Check that rocket-loader.min.js has been removed, as including it breaks landing page redirects.
 		$this->assertStringNotContainsString('rocket-loader.min.js', $result);
-
-		// Check that the <html> tag wasn't replaced, as this isn't a legacy landing page.
-		// It should be preserved as e.g. <html lang="en">.
-		$this->assertStringContainsString('<html lang="en">');
-		$this->assertStringNotContainsString('<html>');
 	}
 
 	/**
@@ -6224,7 +6219,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		$this->assertStringNotContainsString('rocket-loader.min.js', $result);
 
 		// Check that the <html> tag was added, as this isn't included in legacy landing pages.
-		$this->assertStringContainsString('<html>');
+		$this->assertStringContainsString('<html>', $result);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes this reported issue by checking for any `<html>` tags, such as `<html lang`.

Before:
![Screenshot 2024-09-25 at 11 46 30](https://github.com/user-attachments/assets/58864851-4327-4c30-bba0-51a3c1555f65)

After:
![Screenshot 2024-09-25 at 11 46 50](https://github.com/user-attachments/assets/d79471d4-4f3e-46ca-b369-8d8a37d92425)

## Testing

- `testGetLandingPageHTML`: Confirm original `<html lang="en">` is preserved
- `testGetLegacyLandingPageHTML`: Confirm `<html>` tag was added, as this isn't included when fetching legacy landing pages.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)