### PR TITLE
Remove prepended Cloudflare string from JS script type

### DIFF
--- a/src/class-convertkit-api-traits.php
+++ b/src/class-convertkit-api-traits.php
@@ -1675,6 +1675,29 @@ trait ConvertKit_API_Traits
     }
 
     /**
+     * Sets the type attribute for script elements to 'text/javascript',
+     * where Cloudflare prepends a random string to the type attribute.
+     *
+     * @param \DOMNodeList<\DOMElement> $elements Elements.
+     *
+     * @since 2.0.4
+     *
+     * @return void
+     */
+    public function convert_script_type(\DOMNodeList $elements)
+    {
+        foreach ($elements as $element) {
+            // Skip if the attribute is not prepended with a Cloudflare random string
+            if (strpos($element->getAttribute('type'), '-text/javascript') === false) {
+                continue;
+            }
+
+            // Set attribute to 'text/javascript'.
+            $element->setAttribute('type', 'text/javascript');
+        }
+    }
+
+    /**
      * Strips <html>, <head> and <body> opening and closing tags from the given markup,
      * as well as the Content-Type meta tag we might have added in get_html().
      *

--- a/src/class-convertkit-api-v4.php
+++ b/src/class-convertkit-api-v4.php
@@ -1267,6 +1267,9 @@ class ConvertKit_API_V4 {
 		$this->convert_relative_to_absolute_urls( $html->getElementsByTagName( 'script' ), 'src', $url_scheme_host_only );
 		$this->convert_relative_to_absolute_urls( $html->getElementsByTagName( 'form' ), 'action', $url_scheme_host_only );
 
+		// Replace type="{random-string}-text/javascript" with "text/javascript".
+		//$this->convert_script_type( $html->getElementsByTagName( 'script' ) );
+
 		// If the entire HTML needs to be returned, return it now.
 		if ( ! $body_only ) {
 			return $html->saveHTML();

--- a/src/class-convertkit-api-v4.php
+++ b/src/class-convertkit-api-v4.php
@@ -1268,7 +1268,7 @@ class ConvertKit_API_V4 {
 		$this->convert_relative_to_absolute_urls( $html->getElementsByTagName( 'form' ), 'action', $url_scheme_host_only );
 
 		// Replace type="{random-string}-text/javascript" with "text/javascript".
-		//$this->convert_script_type( $html->getElementsByTagName( 'script' ) );
+		$this->convert_script_type( $html->getElementsByTagName( 'script' ) );
 
 		// If the entire HTML needs to be returned, return it now.
 		if ( ! $body_only ) {

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -6178,6 +6178,10 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		// Check that rocket-loader.min.js has been removed, as including it breaks landing page redirects.
 		$this->assertStringNotContainsString('rocket-loader.min.js', $result);
 
+		// Check that all Cloudflare / rocket-loader.min.js script types have their prepended random string removed
+		// e.g. type="d4d618933d20ff16d2d8ebb4-text/javascript" --> type="text/javascript".
+		$this->assertStringNotContainsString('-text/javascript"', $result);
+
 		// Check that the <html> tag wasn't replaced, as this isn't a legacy landing page.
 		// It should be preserved as e.g. <html lang="en">.
 		$this->assertStringContainsString('<html lang="en">', $result);
@@ -6201,6 +6205,10 @@ class APITest extends \Codeception\TestCase\WPTestCase
 
 		// Check that rocket-loader.min.js has been removed, as including it breaks landing page redirects.
 		$this->assertStringNotContainsString('rocket-loader.min.js', $result);
+
+		// Check that all Cloudflare / rocket-loader.min.js script types have their prepended random string removed
+		// e.g. type="d4d618933d20ff16d2d8ebb4-text/javascript" --> type="text/javascript".
+		$this->assertStringNotContainsString('-text/javascript"', $result);
 	}
 
 	/**
@@ -6217,6 +6225,10 @@ class APITest extends \Codeception\TestCase\WPTestCase
 
 		// Check that rocket-loader.min.js has been removed, as including it breaks landing page redirects.
 		$this->assertStringNotContainsString('rocket-loader.min.js', $result);
+
+		// Check that all Cloudflare / rocket-loader.min.js script types have their prepended random string removed
+		// e.g. type="d4d618933d20ff16d2d8ebb4-text/javascript" --> type="text/javascript".
+		$this->assertStringNotContainsString('-text/javascript"', $result);
 
 		// Check that the <html> tag was added, as this isn't included in legacy landing pages.
 		$this->assertStringContainsString('<html>', $result);


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://linear.app/kit/issue/BCDC-3248/bcdc-wordpress-plugin-injecting-apparent-gibberish-into-script-tags) by ensuring JS `type` attributes prepended with Cloudflare's randomized string are converted to `text/javascript`.

We removed `rocket-loader.min.js` [in this PR](https://github.com/ConvertKit/convertkit-wordpress-libraries/pull/77), as it was breaking redirects on Landing Pages.  The side effect of this is JS isn't executing on Landing Pages, as scripts still retained e.g. `type="d4d618933d20ff16d2d8ebb4-text/javascript"`.

## Testing

- Updated tests to check that script types have their prepended random string removed.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)