### PR TITLE
OAuth: Support `tenant_name` Parameter

### DIFF
--- a/src/class-convertkit-api-v4.php
+++ b/src/class-convertkit-api-v4.php
@@ -339,10 +339,11 @@ class ConvertKit_API_V4 {
 	 *
 	 * @since   2.0.0
 	 *
-	 * @param   bool|string $return_url  Return URL.
-	 * @return  string                       OAuth URL
+	 * @param   bool|string $return_url   Return URL.
+	 * @param   bool|string $tenant_name  Tenant Name (if specified, issues tokens specific to that name. Useful for using the same account on multiple sites).
+	 * @return  string                    OAuth URL
 	 */
-	public function get_oauth_url( $return_url = false ) {
+	public function get_oauth_url( $return_url = false, $tenant_name = false ) {
 
 		// Generate and store code verifier and challenge.
 		$code_verifier  = $this->generate_and_store_code_verifier();
@@ -366,6 +367,10 @@ class ConvertKit_API_V4 {
 					)
 				)
 			);
+		}
+
+		if ( $tenant_name ) {
+			$args['tenant_name'] = rawurlencode( $tenant_name );
 		}
 
 		// Return OAuth URL.

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -366,6 +366,32 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
+	 * Test that get_oauth_url() returns the correct URL to begin the OAuth process
+	 * when a tenant_name parameter is supplied.
+	 *
+	 * @since   2.0.5
+	 *
+	 * @return  void
+	 */
+	public function testGetOAuthURLWithTenantName()
+	{
+		// Confirm the OAuth URL returned is correct.
+		$this->assertEquals(
+			$this->api->get_oauth_url( false, 'https://example.com' ),
+			'https://app.kit.com/oauth/authorize?' . http_build_query(
+				[
+					'client_id'             => $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
+					'response_type'         => 'code',
+					'redirect_uri'          => $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
+					'code_challenge'        => $this->api->generate_code_challenge( $this->api->get_code_verifier() ),
+					'code_challenge_method' => 'S256',
+					'tenant_name'           => 'https://example.com',
+				]
+			)
+		);
+	}
+
+	/**
 	 * Test that get_access_token() returns the expected data.
 	 *
 	 * @since   2.0.0


### PR DESCRIPTION
## Summary

Adds support for specifying the [`tenant_name` parameter,](https://github.com/ConvertKit/convertkit/pull/31381) to issue unique OAuth tokens to multiple instances using the same Kit account and OAuth Client / App ID. 

## Testing

`testGetOAuthURLWithTenantName`: Confirm that the `tenant_name` is included in the OAuth URL.

Manual end to end test completing OAuth flow with the same Kit account and OAuth Client / App ID confirms this working:

![Screenshot_2024-11-11_at_09_22_52](https://github.com/user-attachments/assets/7e7905d7-ac69-4b72-af55-543f9b2fc383)
![Screenshot_2024-11-11_at_09_22_59](https://github.com/user-attachments/assets/2f7254b4-554b-4845-8c88-ca54502acb13)

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)