### PR TITLE
Add `revoke_tokens` method

### DIFF
--- a/src/class-convertkit-api-v4.php
+++ b/src/class-convertkit-api-v4.php
@@ -466,17 +466,18 @@ class ConvertKit_API_V4 {
 	}
 
 	/**
-	 * Revokes the current access token.
+	 * Revokes the current access and refresh tokens.
 	 *
 	 * @since   2.1.4
 	 */
-	public function revoke_token() {
+	public function revoke_tokens() {
 
+		// Revoke the access token.
 		$result = $this->post(
 			'revoke',
 			array(
-				'client_id'    => $this->client_id,
-				'access_token' => $this->access_token,
+				'client_id' => $this->client_id,
+				'token'     => $this->access_token,
 			)
 		);
 
@@ -492,7 +493,33 @@ class ConvertKit_API_V4 {
 			 * @param   WP_Error  $result     Error from API.
 			 * @param   string    $client_id  OAuth Client ID.
 			 */
-			do_action( 'convertkit_api_revoke_token_error', $result, $this->client_id );
+			do_action( 'convertkit_api_revoke_tokens_access_token_error', $result, $this->client_id );
+
+			return $result;
+		}
+
+		// Revoke the refresh token.
+		$result = $this->post(
+			'revoke',
+			array(
+				'client_id' => $this->client_id,
+				'token'     => $this->refresh_token,
+			)
+		);
+
+		// If an error occured, log and return it now.
+		if ( is_wp_error( $result ) ) {
+			$this->log( 'API: Error: ' . $result->get_error_message() );
+
+			/**
+			 * Perform any actions when revoking a refresh token fails.
+			 *
+			 * @since   2.1.4
+			 *
+			 * @param   WP_Error  $result     Error from API.
+			 * @param   string    $client_id  OAuth Client ID.
+			 */
+			do_action( 'convertkit_api_revoke_tokens_refresh_token_error', $result, $this->client_id );
 
 			return $result;
 		}
@@ -506,7 +533,7 @@ class ConvertKit_API_V4 {
 		$this->refresh_token = '';
 
 		/**
-		 * Perform any actions when the access token is revoked, such as deleting them from the database.
+		 * Perform any actions when the tokens are revoked, such as deleting them from the database.
 		 *
 		 * @since   2.1.4
 		 *
@@ -514,7 +541,7 @@ class ConvertKit_API_V4 {
 		 * @param   string  $previous_access_token   Existing Access Token.
 		 * @param   string  $previous_refresh_token  Existing Refresh Token.
 		 */
-		do_action( 'convertkit_api_revoke_token', $this->client_id, $previous_access_token, $previous_refresh_token );
+		do_action( 'convertkit_api_revoke_tokens', $this->client_id, $previous_access_token, $previous_refresh_token );
 
 		// Return.
 		return $result;

--- a/src/class-convertkit-api-v4.php
+++ b/src/class-convertkit-api-v4.php
@@ -89,6 +89,7 @@ class ConvertKit_API_V4 {
 	 */
 	protected $api_endpoints_oauth = array(
 		'token',
+		'revoke',
 	);
 
 	/**
@@ -458,6 +459,62 @@ class ConvertKit_API_V4 {
 		 * @param   string  $previous_refresh_token  Existing Refresh Token.
 		 */
 		do_action( 'convertkit_api_refresh_token', $result, $this->client_id, $previous_access_token, $previous_refresh_token );
+
+		// Return.
+		return $result;
+
+	}
+
+	/**
+	 * Revokes the current access token.
+	 *
+	 * @since   2.1.4
+	 */
+	public function revoke_token() {
+
+		$result = $this->post(
+			'revoke',
+			array(
+				'client_id'    => $this->client_id,
+				'access_token' => $this->access_token,
+			)
+		);
+
+		// If an error occured, log and return it now.
+		if ( is_wp_error( $result ) ) {
+			$this->log( 'API: Error: ' . $result->get_error_message() );
+
+			/**
+			 * Perform any actions when revoking an access token fails.
+			 *
+			 * @since   2.1.4
+			 *
+			 * @param   WP_Error  $result     Error from API.
+			 * @param   string    $client_id  OAuth Client ID.
+			 */
+			do_action( 'convertkit_api_revoke_token_error', $result, $this->client_id );
+
+			return $result;
+		}
+
+		// Store existing access and refresh tokens.
+		$previous_access_token  = $this->access_token;
+		$previous_refresh_token = $this->refresh_token;
+
+		// Remove access and refresh tokens from this class.
+		$this->access_token  = '';
+		$this->refresh_token = '';
+
+		/**
+		 * Perform any actions when the access token is revoked, such as deleting them from the database.
+		 *
+		 * @since   2.1.4
+		 *
+		 * @param   string  $client_id               OAuth Client ID.
+		 * @param   string  $previous_access_token   Existing Access Token.
+		 * @param   string  $previous_refresh_token  Existing Refresh Token.
+		 */
+		do_action( 'convertkit_api_revoke_token', $this->client_id, $previous_access_token, $previous_refresh_token );
 
 		// Return.
 		return $result;

--- a/tests/Integration/APITest.php
+++ b/tests/Integration/APITest.php
@@ -529,28 +529,41 @@ class APITest extends WPTestCase
 	}
 
 	/**
-	 * Test that revoke_token() returns the expected data.
+	 * Test that the access token and refresh token are revoked when revoke_token() is called.
 	 *
 	 * @since   2.1.4
-	 *
-	 * @return void
 	 */
 	public function testRevokeToken()
 	{
-		// Add mock handler for this API request, as this results in the
-		// access token being revoked, which would result in
-		// other tests breaking due to changed tokens.
-		$this->mockResponses(
-			httpCode: 200,
-			httpMessage: 'OK',
-			body: wp_json_encode(
-				array()
-			)
+		// Initialize the API without an access token or refresh token.
+		$api = new \ConvertKit_API_V4(
+			$_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
+			$_ENV['CONVERTKIT_OAUTH_REDIRECT_URI']
 		);
 
-		$result = $this->api->revoke_token();
-		$this->assertNotInstanceOf(\WP_Error::class, $result);
-		$this->assertIsArray($result);
+		// Generate an access token by API key and secret.
+		$result = $api->get_access_token_by_api_key_and_secret(
+			$_ENV['CONVERTKIT_API_KEY'],
+			$_ENV['CONVERTKIT_API_SECRET'],
+			wp_generate_password( 10, false ) // Random tenant name to produce a token for this request only.
+		);
+
+		// Initialize the API with the access token and refresh token.
+		$api = new \ConvertKit_API_V4(
+			$_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
+			$_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
+			$result['oauth']['access_token'],
+			$result['oauth']['refresh_token']
+		);
+
+		// Confirm the token works when making an authenticated request.
+		$this->assertNotInstanceOf( 'WP_Error', $api->get_account() );
+
+		// Revoke the access token.
+		$api->revoke_token();
+
+		// Confirm the token no longer works when making an authenticated request.
+		$this->assertInstanceOf( 'WP_Error', $api->get_account() );
 	}
 
 	/**

--- a/tests/Integration/APITest.php
+++ b/tests/Integration/APITest.php
@@ -529,11 +529,11 @@ class APITest extends WPTestCase
 	}
 
 	/**
-	 * Test that the access token and refresh token are revoked when revoke_token() is called.
+	 * Test that the access token and refresh token are revoked when revoke_tokens() is called.
 	 *
 	 * @since   2.1.4
 	 */
-	public function testRevokeToken()
+	public function testRevokeTokens()
 	{
 		// Initialize the API without an access token or refresh token.
 		$api = new \ConvertKit_API_V4(
@@ -559,11 +559,24 @@ class APITest extends WPTestCase
 		// Confirm the token works when making an authenticated request.
 		$this->assertNotInstanceOf( 'WP_Error', $api->get_account() );
 
-		// Revoke the access token.
-		$api->revoke_token();
+		// Revoke the access and refresh tokens.
+		$api->revoke_tokens();
 
-		// Confirm the token no longer works when making an authenticated request.
+		// Initialize the API with the (now revoked) access token and refresh token.
+		// revoke_tokens() will have removed the access token and refresh token from the API class, so we need to provide them again
+		// to test they're revoked.
+		$api = new \ConvertKit_API_V4(
+			$_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
+			$_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'],
+			$result['oauth']['access_token'],
+			$result['oauth']['refresh_token']
+		);
+
+		// Confirm attempting to use the revoked access token no longer works.
 		$this->assertInstanceOf( 'WP_Error', $api->get_account() );
+
+		// Confirm attempting to use the revoked refresh token no longer works.
+		$this->assertInstanceOf( 'WP_Error', $api->refresh_token() );
 	}
 
 	/**

--- a/tests/Integration/APITest.php
+++ b/tests/Integration/APITest.php
@@ -529,6 +529,31 @@ class APITest extends WPTestCase
 	}
 
 	/**
+	 * Test that revoke_token() returns the expected data.
+	 *
+	 * @since   2.1.4
+	 *
+	 * @return void
+	 */
+	public function testRevokeToken()
+	{
+		// Add mock handler for this API request, as this results in the
+		// access token being revoked, which would result in
+		// other tests breaking due to changed tokens.
+		$this->mockResponses(
+			httpCode: 200,
+			httpMessage: 'OK',
+			body: wp_json_encode(
+				array()
+			)
+		);
+
+		$result = $this->api->revoke_token();
+		$this->assertNotInstanceOf(\WP_Error::class, $result);
+		$this->assertIsArray($result);
+	}
+
+	/**
 	 * Test that supplying no API credentials to the API class returns a WP_Error.
 	 *
 	 * @since   2.0.2


### PR DESCRIPTION
## Summary

Adds the `revoke_tokens` method, allowing Kit Plugins to revoke an access token when e.g. the user disconnects the Plugin from Kit.

## Testing

- `testRevokeTokens` tests the `revoke_tokens` method revokes the access and refresh tokens

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)