### PR TITLE
Ignore invalid Resource arrays

### DIFF
--- a/src/class-convertkit-resource-v4.php
+++ b/src/class-convertkit-resource-v4.php
@@ -181,14 +181,14 @@ class ConvertKit_Resource_V4 {
 	 */
 	public function get_by( $key, $value ) {
 
+		// Don't attempt sorting if no resources exist.
+		if ( ! $this->exist() ) {
+			return false;
+		}
+
 		// Don't mutate the underlying resources, so multiple calls to get()
 		// with different order_by and order properties are supported.
 		$resources = $this->resources;
-
-		// Don't attempt sorting if no resources exist.
-		if ( ! $this->exist() ) {
-			return $resources;
-		}
 
 		foreach ( $resources as $id => $resource ) {
 			// Remove this resource if it doesn't have the array key.
@@ -329,6 +329,21 @@ class ConvertKit_Resource_V4 {
 		}
 
 		if ( is_null( $this->resources ) ) {
+			return false;
+		}
+
+		// If the resources are not an array, no resources exist.
+		if ( ! is_array( $this->resources ) ) {
+			return false;
+		}
+
+		// Ignore cached resources stored in the options table if they are a flat array
+		// that originates from between 1.6.0 and 1.9.5.2 of the Plugin
+		// i.e. [id => name], rather than [id => [id => '...', name => '...', ...]].
+		// The Plugin's upgrade routine must handle converting the flat array to the new array format, but the
+		// resource classes are typically loaded before this happens, so this check is necessary to avoid
+		// fatal errors when a user upgrades from 1.6.0...1.9.5.2 to 1.9.6 or higher.
+		if ( ! is_array( reset( $this->resources ) ) ) {
 			return false;
 		}
 

--- a/tests/Integration/ResourceTest.php
+++ b/tests/Integration/ResourceTest.php
@@ -699,7 +699,8 @@ class ResourceTest extends WPTestCase
 	}
 
 	/**
-	 * Defines an array of resources when mocking invalid resource data in tests.
+	 * Defines an array of resources when mocking resource data in tests,
+	 * in a format stored in the WordPress Plugins prior to using these Libraries.
 	 *
 	 * @since   2.1.6
 	 */

--- a/tests/Integration/ResourceTest.php
+++ b/tests/Integration/ResourceTest.php
@@ -259,6 +259,34 @@ class ResourceTest extends WPTestCase
 	}
 
 	/**
+	 * Tests that the get_by() function returns false when queried with invalid resource data.
+	 *
+	 * @since   2.1.6
+	 */
+	public function testGetByWithInvalidResourceData()
+	{
+		// Mock invalid resource data.
+		$this->mockInvalidData();
+
+		// Assert result is false.
+		$this->assertFalse($this->resource->get_by('name', 'Z Name'));
+	}
+
+	/**
+	 * Tests that the exist() function returns false when queried with invalid resource data.
+	 *
+	 * @since   2.1.6
+	 */
+	public function testExistWithInvalidResourceData()
+	{
+		// Mock invalid resource data.
+		$this->mockInvalidData();
+
+		// Assert result is false.
+		$this->assertFalse($this->resource->exist());
+	}
+
+	/**
 	 * Tests that the refresh() function for Forms returns resources in an array, and that they are
 	 * in alphabetical ascending order by default.
 	 *
@@ -667,6 +695,18 @@ class ResourceTest extends WPTestCase
 				'title'        => 'A Name', // 'title' used by posts.
 				'published_at' => '2022-05-03T14:51:50.000Z', // used by posts.
 			],
+		];
+	}
+
+	/**
+	 * Defines an array of resources when mocking invalid resource data in tests.
+	 *
+	 * @since   2.1.6
+	 */
+	private function mockInvalidData()
+	{
+		$this->resource->resources = [
+			2780977 => 'Resource',
 		];
 	}
 }


### PR DESCRIPTION
## Summary

Return false when using the `exist` method when the array of resource data is a flat array, which isn't the structure used for any resources in any Plugins since 2022.

Implemented in [this PR](https://github.com/Kit/convertkit-wordpress/pull/1073).

## Testing

- `testGetByWithInvalidResourceData`: Tests that the get_by() function returns false when queried with invalid resource data.
- `testExistWithInvalidResourceData`: Tests that the exist() function returns false when queried with invalid resource data.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)