### PR TITLE
Tests: Replace `bounced` tests + fix Invalid Custom Field Test

### DIFF
--- a/tests/Integration/APITest.php
+++ b/tests/Integration/APITest.php
@@ -3924,7 +3924,7 @@ class APITest extends WPTestCase
 	}
 
 	/**
-	 * Test that create_subscriber() returns the expected data
+	 * Test that create_subscriber() returns a WP_Error
 	 * when an invalid custom field is included.
 	 *
 	 * @since   2.0.0
@@ -3940,14 +3940,8 @@ class APITest extends WPTestCase
 				'not_a_custom_field' => 'value',
 			]
 		);
-		$this->assertNotInstanceOf(\WP_Error::class, $result);
-		$this->assertIsArray($result);
-
-		// Set subscriber_id to ensure subscriber is unsubscribed after test.
-		$this->subscriber_ids[] = $result['subscriber']['id'];
-
-		// Assert subscriber exists with correct data.
-		$this->assertEquals($result['subscriber']['email_address'], $emailAddress);
+		$this->assertInstanceOf(\WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
 	}
 
 	/**

--- a/tests/Integration/APITest.php
+++ b/tests/Integration/APITest.php
@@ -1379,11 +1379,11 @@ class APITest extends WPTestCase
 	 *
 	 * @return void
 	 */
-	public function testGetFormSubscriptionsWithBouncedSubscriberState()
+	public function testGetFormSubscriptionsWithCancelledSubscriberState()
 	{
 		$result = $this->api->get_form_subscriptions(
 			form_id: (int) $_ENV['CONVERTKIT_API_FORM_ID'],
-			subscriber_state: 'bounced'
+			subscriber_state: 'cancelled'
 		);
 
 		// Assert subscribers and pagination exist.
@@ -1391,7 +1391,7 @@ class APITest extends WPTestCase
 		$this->assertPaginationExists($result);
 
 		// Check the correct subscribers were returned.
-		$this->assertEquals($result['subscribers'][0]['state'], 'bounced');
+		$this->assertEquals($result['subscribers'][0]['state'], 'cancelled');
 	}
 
 	/**
@@ -2374,11 +2374,11 @@ class APITest extends WPTestCase
 	 *
 	 * @return void
 	 */
-	public function testGetSequenceSubscriptionsWithBouncedSubscriberState()
+	public function testGetSequenceSubscriptionsWithCancelledSubscriberState()
 	{
 		$result = $this->api->get_sequence_subscriptions(
 			sequence_id: $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
-			subscriber_state: 'bounced'
+			subscriber_state: 'cancelled'
 		);
 
 		// Assert subscribers and pagination exist.
@@ -2386,7 +2386,7 @@ class APITest extends WPTestCase
 		$this->assertPaginationExists($result);
 
 		// Check the correct subscribers were returned.
-		$this->assertEquals($result['subscribers'][0]['state'], 'bounced');
+		$this->assertEquals($result['subscribers'][0]['state'], 'cancelled');
 	}
 
 	/**
@@ -3213,11 +3213,11 @@ class APITest extends WPTestCase
 	 *
 	 * @return void
 	 */
-	public function testGetTagSubscriptionsWithBouncedSubscriberState()
+	public function testGetTagSubscriptionsWithCancelledSubscriberState()
 	{
 		$result = $this->api->get_tag_subscriptions(
 			tag_id: (int) $_ENV['CONVERTKIT_API_TAG_ID'],
-			subscriber_state: 'bounced'
+			subscriber_state: 'cancelled'
 		);
 
 		// Assert subscribers and pagination exist.
@@ -3225,7 +3225,7 @@ class APITest extends WPTestCase
 		$this->assertPaginationExists($result);
 
 		// Check the correct subscribers were returned.
-		$this->assertEquals($result['subscribers'][0]['state'], 'bounced');
+		$this->assertEquals($result['subscribers'][0]['state'], 'cancelled');
 	}
 
 
@@ -3486,16 +3486,16 @@ class APITest extends WPTestCase
 
 	/**
 	 * Test that get_subscribers() returns the expected data
-	 * when the subscription status is bounced.
+	 * when the subscription status is cancelled.
 	 *
 	 * @since   1.0.0
 	 *
 	 * @return void
 	 */
-	public function testGetSubscribersWithBouncedSubscriberState()
+	public function testGetSubscribersWithCancelledSubscriberState()
 	{
 		$result = $this->api->get_subscribers(
-			subscriber_state: 'bounced'
+			subscriber_state: 'cancelled'
 		);
 
 		// Assert subscribers and pagination exist.
@@ -3503,7 +3503,7 @@ class APITest extends WPTestCase
 		$this->assertPaginationExists($result);
 
 		// Check the correct subscribers were returned.
-		$this->assertEquals($result['subscribers'][0]['state'], 'bounced');
+		$this->assertEquals($result['subscribers'][0]['state'], 'cancelled');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes failing tests by checking for cancelled subscribers, as there are no bounced subscribers with forms, tags and sequences in the Kit account:

<img width="899" height="226" alt="Screenshot 2026-05-15 at 19 28 26" src="https://github.com/user-attachments/assets/0c1e4dc0-3889-4501-89dd-5eb06f95eba9" />

Updates the `testCreateSubscriberWithInvalidCustomFields`, as creating a subscriber with an invalid custom field will now return an error [due to this PR](https://github.com/Kit/convertkit/pull/42934).

## Testing

- Updated existing tests

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)