### PR TITLE
Tests: Fix `testCreateSubscriberWithInvalidCustomFields`

### DIFF
--- a/tests/Integration/APITest.php
+++ b/tests/Integration/APITest.php
@@ -3924,7 +3924,7 @@ class APITest extends WPTestCase
 	}
 
 	/**
-	 * Test that create_subscriber() returns the expected data
+	 * Test that create_subscriber() returns a WP_Error
 	 * when an invalid custom field is included.
 	 *
 	 * @since   2.0.0
@@ -3940,14 +3940,8 @@ class APITest extends WPTestCase
 				'not_a_custom_field' => 'value',
 			]
 		);
-		$this->assertNotInstanceOf(\WP_Error::class, $result);
-		$this->assertIsArray($result);
-
-		// Set subscriber_id to ensure subscriber is unsubscribed after test.
-		$this->subscriber_ids[] = $result['subscriber']['id'];
-
-		// Assert subscriber exists with correct data.
-		$this->assertEquals($result['subscriber']['email_address'], $emailAddress);
+		$this->assertInstanceOf(\WP_Error::class, $result);
+		$this->assertEquals($result->get_error_code(), $this->errorCode);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Updates the `testCreateSubscriberWithInvalidCustomFields`, as creating a subscriber with an invalid custom field will now return an error [due to this PR](https://github.com/Kit/convertkit/pull/42934).

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)