### PR TITLE
Fix Unsubscribe Tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,7 @@ jobs:
     # Defines the WordPress and PHP Versions matrix to run tests on.
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         wp-versions: [ 'latest' ] #[ '6.1.1', 'latest' ]
         php-versions: [ '8.0', '8.1', '8.2', '8.3', '8.4' ] #[ '7.4', '8.0', '8.1', '8.2' ]

--- a/tests/Integration/APITest.php
+++ b/tests/Integration/APITest.php
@@ -4245,14 +4245,14 @@ class APITest extends WPTestCase
 	 */
 	public function testUnsubscribeByEmail()
 	{
-		// Avoid a rate limit due to previous tests.
-		sleep(2);
-
 		// Add a subscriber.
 		$emailAddress = $this->generateEmailAddress();
 		$result       = $this->api->create_subscriber($emailAddress);
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
 		$this->assertIsArray($result);
+
+		// Wait a moment to ensure subscriber is created.
+		sleep(3);
 
 		// Unsubscribe.
 		$this->assertNull($this->api->unsubscribe_by_email($emailAddress));
@@ -4300,6 +4300,9 @@ class APITest extends WPTestCase
 		$result       = $this->api->create_subscriber($emailAddress);
 		$this->assertNotInstanceOf(\WP_Error::class, $result);
 		$this->assertIsArray($result);
+
+		// Wait a moment to ensure subscriber is created.
+		sleep(3);
 
 		// Unsubscribe.
 		$this->assertNull($this->api->unsubscribe($result['subscriber']['id']));


### PR DESCRIPTION
## Summary

Improve reliability of unsubscribe tests by waiting for the subscriber to be created before unsubscribing them.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)