### PR TITLE
Tests: Update GitHub Actions for Node 20 deprecation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -129,22 +129,19 @@ jobs:
 
       # Write any secrets, such as API keys, to the .env.testing file now.
       - name: Define GitHub Secrets in .env.testing
-        uses: DamianReeves/write-file-action@v1.3
-        with:
-          path: ${{ env.PLUGIN_DIR }}/.env.testing
-          contents: |
-            CONVERTKIT_API_KEY=${{ env.CONVERTKIT_API_KEY }}
-            CONVERTKIT_API_SECRET=${{ env.CONVERTKIT_API_SECRET }}
-            CONVERTKIT_OAUTH_ACCESS_TOKEN=${{ env.CONVERTKIT_OAUTH_ACCESS_TOKEN }}
-            CONVERTKIT_OAUTH_REFRESH_TOKEN=${{ env.CONVERTKIT_OAUTH_REFRESH_TOKEN }}
-            CONVERTKIT_OAUTH_ACCESS_TOKEN_NO_DATA=${{ env.CONVERTKIT_OAUTH_ACCESS_TOKEN_NO_DATA }}
-            CONVERTKIT_OAUTH_REFRESH_TOKEN_NO_DATA=${{ env.CONVERTKIT_OAUTH_REFRESH_TOKEN_NO_DATA }}
-            CONVERTKIT_OAUTH_CLIENT_ID=${{ env.CONVERTKIT_OAUTH_CLIENT_ID }}
-            CONVERTKIT_OAUTH_REDIRECT_URI=${{ env.CONVERTKIT_OAUTH_REDIRECT_URI }}
-            CONVERTKIT_API_SIGNED_SUBSCRIBER_ID=${{ env.CONVERTKIT_API_SIGNED_SUBSCRIBER_ID }}
-            CONVERTKIT_API_SUBSCRIBER_TOKEN=${{ env.CONVERTKIT_API_SUBSCRIBER_TOKEN }}
-
-          write-mode: append
+        run: |
+          cat > ${{ env.PLUGIN_DIR }}/.env.testing << 'ENVEOF'
+          CONVERTKIT_API_KEY=${{ env.CONVERTKIT_API_KEY }}
+          CONVERTKIT_API_SECRET=${{ env.CONVERTKIT_API_SECRET }}
+          CONVERTKIT_OAUTH_ACCESS_TOKEN=${{ env.CONVERTKIT_OAUTH_ACCESS_TOKEN }}
+          CONVERTKIT_OAUTH_REFRESH_TOKEN=${{ env.CONVERTKIT_OAUTH_REFRESH_TOKEN }}
+          CONVERTKIT_OAUTH_ACCESS_TOKEN_NO_DATA=${{ env.CONVERTKIT_OAUTH_ACCESS_TOKEN_NO_DATA }}
+          CONVERTKIT_OAUTH_REFRESH_TOKEN_NO_DATA=${{ env.CONVERTKIT_OAUTH_REFRESH_TOKEN_NO_DATA }}
+          CONVERTKIT_OAUTH_CLIENT_ID=${{ env.CONVERTKIT_OAUTH_CLIENT_ID }}
+          CONVERTKIT_OAUTH_REDIRECT_URI=${{ env.CONVERTKIT_OAUTH_REDIRECT_URI }}
+          CONVERTKIT_API_SIGNED_SUBSCRIBER_ID=${{ env.CONVERTKIT_API_SIGNED_SUBSCRIBER_ID }}
+          CONVERTKIT_API_SUBSCRIBER_TOKEN=${{ env.CONVERTKIT_API_SUBSCRIBER_TOKEN }}
+          ENVEOF
 
       # Installs wp-browser, Codeception, PHP CodeSniffer and anything else needed to run tests.
       - name: Run Composer

--- a/tests/Integration/APITest.php
+++ b/tests/Integration/APITest.php
@@ -3924,7 +3924,7 @@ class APITest extends WPTestCase
 	}
 
 	/**
-	 * Test that create_subscriber() returns a WP_Error
+	 * Test that create_subscriber() returns the expected data
 	 * when an invalid custom field is included.
 	 *
 	 * @since   2.0.0
@@ -3940,8 +3940,14 @@ class APITest extends WPTestCase
 				'not_a_custom_field' => 'value',
 			]
 		);
-		$this->assertInstanceOf(\WP_Error::class, $result);
-		$this->assertEquals($result->get_error_code(), $this->errorCode);
+		$this->assertNotInstanceOf(\WP_Error::class, $result);
+		$this->assertIsArray($result);
+
+		// Set subscriber_id to ensure subscriber is unsubscribed after test.
+		$this->subscriber_ids[] = $result['subscriber']['id'];
+
+		// Assert subscriber exists with correct data.
+		$this->assertEquals($result['subscriber']['email_address'], $emailAddress);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Replaces `DamianReeves/write-file-action` with a shell command, as there's no new version using Node version above 20. 

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)