### PR TITLE
Move legacy landing pages and forms to legacy_landing_pages endpoint

### DIFF
--- a/src/class-convertkit-api-v4.php
+++ b/src/class-convertkit-api-v4.php
@@ -847,7 +847,7 @@ class ConvertKit_API_V4 {
 		int $per_page = 100
 	) {
 		return $this->get(
-			'landing_pages',
+			'legacy_landing_pages',
 			$this->build_total_count_and_pagination_params(
 				array(
 					'type' => 'hosted',

--- a/src/class-convertkit-api-v4.php
+++ b/src/class-convertkit-api-v4.php
@@ -815,7 +815,7 @@ class ConvertKit_API_V4 {
 		int $per_page = 100
 	) {
 		return $this->get(
-			'landing_pages',
+			'legacy_landing_pages',
 			$this->build_total_count_and_pagination_params(
 				array(
 					'type' => 'embed',


### PR DESCRIPTION
## Summary

Moves the WordPress libraries off the `landing_pages` API endpoint, which the monolith is about to repurpose. Both methods that hit it now call the new byte-identical `legacy_landing_pages` endpoint (Kit/convertkit#44872, confirmed live in production):

- `get_legacy_landing_pages()` — `type => hosted`
- `get_legacy_forms()` — `type => embed`

The new endpoint supports both `type` filters and returns the same shape (keyed `legacy_landing_pages`, same `pagination` object), so nothing else changes. After this, no code calls the old `landing_pages` endpoint.

This is shared library code (convertkit-wordpress / wpforms / membermouse) — releasing needs a new tag (next: `2.1.7`) and a composer bump in each consuming plugin.

## Testing

No test changes are required: the integration tests already exercise both methods and assert on the `legacy_landing_pages` response key — `APITest::testGetLegacyLandingPages` / `testGetLegacyLandingPagesWithTotalCount`, `testGetLegacyForms` / `testGetLegacyFormsWithTotalCount`, and `ResourceTest::testRefreshLandingPages` (which drives `get_legacy_landing_pages()` via `refresh()`). None hardcode the endpoint path, so the switch is transparent.

## Checklist

* [ ] I have [run all tests](TESTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] I have assigned a reviewer or two to review this PR
