### PR TITLE
Tests: Revert `testCreateSubscriberWithInvalidCustomFields`

### DIFF
--- a/tests/Integration/APITest.php
+++ b/tests/Integration/APITest.php
@@ -3924,7 +3924,7 @@ class APITest extends WPTestCase
 	}
 
 	/**
-	 * Test that create_subscriber() returns a WP_Error
+	 * Test that create_subscriber() returns the expected data
 	 * when an invalid custom field is included.
 	 *
 	 * @since   2.0.0
@@ -3940,8 +3940,14 @@ class APITest extends WPTestCase
 				'not_a_custom_field' => 'value',
 			]
 		);
-		$this->assertInstanceOf(\WP_Error::class, $result);
-		$this->assertEquals($result->get_error_code(), $this->errorCode);
+		$this->assertNotInstanceOf(\WP_Error::class, $result);
+		$this->assertIsArray($result);
+
+		// Set subscriber_id to ensure subscriber is unsubscribed after test.
+		$this->subscriber_ids[] = $result['subscriber']['id'];
+
+		// Assert subscriber exists with correct data.
+		$this->assertEquals($result['subscriber']['email_address'], $emailAddress);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Creating a subscriber with invalid custom fields via the API appears to no longer return a HTTP error code, resulting in the `testCreateSubscriberWithInvalidCustomFields` test assertions failing.

This PR resolves by reverting #118, which originally changed the `testCreateSubscriberWithInvalidCustomFields` assertions [due to this PR](https://github.com/Kit/convertkit/pull/42934).

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)