### PR TITLE
Add Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ If you discover a security vulnerability, please report via any of the below:
 - [GitHub](https://github.com/Kit/convertkit-wordpress-libraries/security/advisories)
 - [Email](mailto:security@kit.com)
 
-Please do **not** report security issues publicly via GitHub issues or discussions. Security reports sent via the above channels be acknowledged within 48 hours.
+Please do **not** report security issues publicly via GitHub issues or discussions. Security reports sent via the above channels will be acknowledged within 48 hours.
 
 ## Security Disclosure Process
 
@@ -24,8 +24,8 @@ When reporting a security vulnerability, please include:
 
 ## Security Response Timeline
 
-- **Initial Response**: Within 48 hours of receiving the report
-- **Investigation**: We will investigate and validate the reported vulnerability
+- **Initial Response**: Acknowledgement within 48 hours of receiving the report
+- **Investigation**: Investigation and validation of the reported vulnerability
 - **Fix Development**: Development of a patch or mitigation strategy
 - **Release**: Coordinated disclosure and release of security update
-- **Public Disclosure**: After users have had time to upgrade
+- **Public Disclosure**: Public announcement after users have had time to upgrade

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+This security policy applies to public projects under the [Kit organization](https://github.com/kit) on GitHub.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report via any of the below:
+
+- [BugCrowd](https://docs.bugcrowd.com/researchers/reporting-managing-submissions/reporting-a-bug/#creating-a-vulnerability-report)
+- [PatchStack]()
+- [GitHub](https://github.com/Kit/convertkit-wordpress-libraries/security/advisories)
+- [Email](mailto:security@kit.com)
+
+Please do **not** report security issues publicly via GitHub issues or discussions. Security reports sent via the above channels be acknowledged within 48 hours.
+
+## Security Disclosure Process
+
+When reporting a security vulnerability, please include:
+
+1. **Description** - A clear description of the vulnerability
+2. **Impact** - What kind of vulnerability it is and who it impacts
+3. **Reproduction** - Detailed steps to reproduce the issue
+4. **Proof of Concept** - If applicable, include proof-of-concept code
+5. **Suggested Fix** - If you have ideas for how to fix the issue
+
+## Security Response Timeline
+
+- **Initial Response**: Within 48 hours of receiving the report
+- **Investigation**: We will investigate and validate the reported vulnerability
+- **Fix Development**: Development of a patch or mitigation strategy
+- **Release**: Coordinated disclosure and release of security update
+- **Public Disclosure**: After users have had time to upgrade

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,7 @@ This security policy applies to public projects under the [Kit organization](htt
 
 If you discover a security vulnerability, please report via any of the below:
 
-- [BugCrowd](https://docs.bugcrowd.com/researchers/reporting-managing-submissions/reporting-a-bug/#creating-a-vulnerability-report)
-- [PatchStack]()
+- [Kit](https://kit.com/report-vulnerability)
 - [GitHub](https://github.com/Kit/convertkit-wordpress-libraries/security/advisories)
 - [Email](mailto:security@kit.com)
 


### PR DESCRIPTION
## Summary

Adds a security policy, as we do for the Kit Plugins.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)